### PR TITLE
Unify naming of deploy secrets

### DIFF
--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -60,9 +60,8 @@ jobs:
       - name: Deploy PR mainnet preview to GCP
         uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
-          # FIXME: Consider setting separate uploader keys for each bucket.
-          service-key: ${{ secrets.KEEP_PRD_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
-          project: ${{ secrets.KEEP_PRD_GOOGLE_PROJECT_ID }}
+          service-key: ${{ secrets.MAINNET_PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
+          project: ${{ secrets.MAINNET_PREVIEW_GOOGLE_PROJECT_ID }}
           bucket-name: preview.dashboard.threshold.network
           bucket-path: ${{ github.head_ref }}
           build-folder: build


### PR DESCRIPTION
Unifying naming of deploy secrets to keep them aligned for mainnet preview and mainnet builds.