### PR TITLE
Mainnet dashboard deploy job updates

### DIFF
--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -10,7 +10,6 @@ on:
   release:
     types:
       - "published"
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -59,7 +59,7 @@ jobs:
           service-key: ${{ secrets.MAINNET_PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
           project: ${{ secrets.MAINNET_PREVIEW_GOOGLE_PROJECT_ID }}
           bucket-name: preview.dashboard.threshold.network
-          bucket-path: ${{ github.head_ref }}
+          bucket-path: ${{ github.ref_name }}
           build-folder: build
 
   deploy:

--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -3,9 +3,6 @@ name: Token Dashboard / Mainnet
 on:
   push:
     branches:
-      - main
-  pull_request:
-    branches:
       - releases/mainnet/**
   release:
     types:
@@ -65,22 +62,10 @@ jobs:
           bucket-path: ${{ github.head_ref }}
           build-folder: build
 
-      - name: Post mainnet preview URL to PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v5
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Preview uploaded to https://preview.dashboard.threshold.network/${{ github.head_ref }}/index.html.'
-            })
-
   deploy:
     name: Deploy mainnet
     needs: build
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'release'
     # mainnet environment is protected, it requires an approval before execution.
     environment:
       name: mainnet

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows/dashboard-mainnet.yml @pdyraga @nkuba @lukasz-zimnoch


### PR DESCRIPTION
Mainnet deployment procedure:
- any developer with write access to `threshold-network/token-dashboard` creates a release branch: `releases/mainnet/v1.0`
- preview of the release branch will be uploaded to preview.dashboard.threshold.network
- after reviewing the dashboard preview, any developer with write access tags the commit and creates a github release
- one of the selected dashboard ops devs can approve the mainnet release using appropriate action
- once the release action is approved, code is automatically uploaded to dashboard.threshold.network