### PR TITLE
Fix mainnet deployment building

### DIFF
--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -32,9 +32,19 @@ jobs:
       #       @threshold-network/contracts@mainnet
 
       - name: Build
+        if: github.event_name == 'push'
         run: yarn build
         env:
           PUBLIC_URL: /${{ github.ref_name }}
+          CHAIN_ID: 1
+          ETH_HOSTNAME_HTTP: ${{ secrets.MAINNET_ETH_HOSTNAME_HTTP }}
+          ETH_HOSTNAME_WS: ${{ secrets.MAINNET_ETH_HOSTNAME_WS }}
+
+      - name: Build
+        if: github.event_name == 'release'
+        run: yarn build
+        env:
+          PUBLIC_URL: /
           CHAIN_ID: 1
           ETH_HOSTNAME_HTTP: ${{ secrets.MAINNET_ETH_HOSTNAME_HTTP }}
           ETH_HOSTNAME_WS: ${{ secrets.MAINNET_ETH_HOSTNAME_WS }}
@@ -47,6 +57,7 @@ jobs:
   deploy-preview:
     name: Deploy mainnet preview
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build
         run: yarn build
         env:
-          PUBLIC_URL: /${{ github.head_ref }}
+          PUBLIC_URL: /${{ github.ref_name }}
           CHAIN_ID: 1
           ETH_HOSTNAME_HTTP: ${{ secrets.MAINNET_ETH_HOSTNAME_HTTP }}
           ETH_HOSTNAME_WS: ${{ secrets.MAINNET_ETH_HOSTNAME_WS }}


### PR DESCRIPTION
We changed github.head_ref to github.ref_name in deploy mainnet preview
job but missed to change it in PUBLIC_URL definition.

For mainnet deployment we don't want to provide a ref_name in PUBLIC_URL
so the links are routed correctly when deployed to bucket's root
directory.

We build and deploy separate versions for `push` and `release`:
`push` is expected to deploy a mainnet preview version
`relese` is expected to deploy a mainnet version