### PR TITLE
Update T dapp to include `TTokenStaking` contract changes 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Auto-formatted dashboard code via `yarn format:fix` command.
 50c6d966435451b12691611784aa0dd6ad0927fa
+1911b2106aada277cb49835f9983e4ba04a1affa

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 # Production deployment
 
-
 The following procedure allows to deploy T token dashboard to production:
 
 1. Developer with write access to the repository creates a release branch:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { useSubscribeToContractEvent } from "./web3/hooks/useSubscribeToContract
 import { useSubscribeToERC20TransferEvent } from "./web3/hooks/useSubscribeToERC20TransferEvent"
 import { useVendingMachineContract } from "./web3/hooks/useVendingMachineContract"
 import { useModal } from "./hooks/useModal"
-import { useSubscribeToOperatorStakedEvent } from "./hooks/useSubscribeToOperatorStakedEvent"
+import { useSubscribeToStakedEvent } from "./hooks/useSubscribeToStakedEvent"
 import { useSubscribeToUnstakedEvent } from "./hooks/useSubscribeToUnstakedEvent"
 import { useSubscribeToToppedUpEvent } from "./hooks/useSubscribeToToppedUpEvent"
 import { pages } from "./pages"
@@ -36,7 +36,7 @@ const Web3EventHandlerComponent = () => {
   useSubscribeToERC20TransferEvent(Token.Keep)
   useSubscribeToERC20TransferEvent(Token.Nu)
   useSubscribeToERC20TransferEvent(Token.T)
-  useSubscribeToOperatorStakedEvent()
+  useSubscribeToStakedEvent()
   useSubscribeToUnstakedEvent()
   useSubscribeToToppedUpEvent()
 

--- a/src/components/Modal/TopupTModal/index.tsx
+++ b/src/components/Modal/TopupTModal/index.tsx
@@ -67,7 +67,10 @@ const TopupTModal: FC<BaseModalProps & { stake: StakeData }> = ({ stake }) => {
         <Button
           disabled={+amountTopUp == 0 || +amountTopUp > +maxAmount}
           onClick={() =>
-            topup({ operator: stake.operator, amount: amountTopUp })
+            topup({
+              stakingProvider: stake.stakingProvider,
+              amount: amountTopUp,
+            })
           }
         >
           Top Up

--- a/src/components/Modal/UnstakeTModal/index.tsx
+++ b/src/components/Modal/UnstakeTModal/index.tsx
@@ -46,7 +46,7 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
             <AlertIcon />
             <AlertDescription>
               Some info about not using the same operator again:{" "}
-              {stake.operator}
+              {stake.stakingProvider}
             </AlertDescription>
           </Alert>
           <Stack spacing={6} mb={6}>
@@ -73,7 +73,10 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
         <Button
           disabled={+amountToUnstake == 0 || +amountToUnstake > +stake.tStake}
           onClick={() =>
-            unstake({ operator: stake.operator, amount: amountToUnstake })
+            unstake({
+              stakingProvider: stake.stakingProvider,
+              amount: amountToUnstake,
+            })
           }
         >
           Unstake

--- a/src/hooks/useFetchOwnerStakes.ts
+++ b/src/hooks/useFetchOwnerStakes.ts
@@ -19,22 +19,19 @@ export const useFetchOwnerStakes = () => {
         return []
       }
 
-      const operatorStakedEvents = await getContractPastEvents(
-        tStakingContract,
-        {
-          eventName: "OperatorStaked",
-          fromBlock: 0, // TODO: get contract deployment block.
-          filterParams: [undefined, address],
-        }
-      )
+      const stakedEvents = await getContractPastEvents(tStakingContract, {
+        eventName: "Staked",
+        fromBlock: 0, // TODO: get contract deployment block.
+        filterParams: [undefined, address],
+      })
 
-      const stakes = operatorStakedEvents.map((_) => {
+      const stakes = stakedEvents.map((_) => {
         const amount = _.args?.amount.toString()
         const stakeType = _.args?.stakeType as StakeType
         return {
           stakeType,
           owner: _.args?.owner as string,
-          operator: _.args?.operator as string,
+          stakingProvider: _.args?.stakingProvider as string,
           beneficiary: _.args?.beneficiary as string,
           authorizer: _.args?.authorizer as string,
           blockNumber: _.blockNumber,
@@ -49,7 +46,7 @@ export const useFetchOwnerStakes = () => {
       const multicalls = stakes.map((_) => ({
         contract: tStakingContract,
         method: "stakes",
-        args: [_.operator],
+        args: [_.stakingProvider],
       }))
       const multiCallsRequests = multicalls.map(getMulticallContractCall)
 

--- a/src/hooks/useSubscribeToStakedEvent.ts
+++ b/src/hooks/useSubscribeToStakedEvent.ts
@@ -5,20 +5,20 @@ import { BigNumberish } from "@ethersproject/bignumber"
 import { operatorStaked } from "../store/staking"
 import { useSubscribeToContractEvent, useTStakingContract } from "../web3/hooks"
 
-export const useSubscribeToOperatorStakedEvent = () => {
+export const useSubscribeToStakedEvent = () => {
   const tStakingContract = useTStakingContract()
   const { account } = useWeb3React()
   const dispatch = useDispatch()
 
   useSubscribeToContractEvent(
     tStakingContract!,
-    "OperatorStaked",
+    "Staked",
     // TODO: figure out how to type callback.
     // @ts-ignore
     (
       stakeType: number,
       owner: string,
-      operator: string,
+      stakingProvider: string,
       beneficiary: string,
       authorizer: string,
       amount: BigNumberish,
@@ -30,7 +30,7 @@ export const useSubscribeToOperatorStakedEvent = () => {
         operatorStaked({
           stakeType,
           owner,
-          operator,
+          stakingProvider,
           authorizer,
           beneficiary,
           blockHash,

--- a/src/hooks/useSubscribeToToppedUpEvent.ts
+++ b/src/hooks/useSubscribeToToppedUpEvent.ts
@@ -11,10 +11,10 @@ export const useSubscribeToToppedUpEvent = () => {
     "ToppedUp",
     // TODO: figure out how to type callback.
     // @ts-ignore
-    (operator, amount) => {
+    (stakingProvider, amount) => {
       dispatch(
         updateStakeAmountForOperator({
-          operator,
+          stakingProvider,
           amount,
           increaseOrDecrease: "increase",
         })

--- a/src/hooks/useSubscribeToUnstakedEvent.ts
+++ b/src/hooks/useSubscribeToUnstakedEvent.ts
@@ -11,10 +11,10 @@ export const useSubscribeToUnstakedEvent = () => {
     "Unstaked",
     // TODO: figure out how to type callback.
     // @ts-ignore
-    (operator, amount) => {
+    (stakingProvider, amount) => {
       dispatch(
         updateStakeAmountForOperator({
-          operator,
+          stakingProvider,
           amount,
           increaseOrDecrease: "decrease",
         })

--- a/src/pages/Staking/StakesTable/StakeAddressesCell.tsx
+++ b/src/pages/Staking/StakesTable/StakeAddressesCell.tsx
@@ -36,7 +36,7 @@ const StakeAddressesCell: FC<StakeCellProps> = ({ stake }) => {
   return (
     <Td>
       <VStack spacing={2}>
-        <StakingAddressRow text="Operator" address={stake.operator} />
+        <StakingAddressRow text="Operator" address={stake.stakingProvider} />
         <StakingAddressRow text="Beneficiary" address={stake.beneficiary} />
         <StakingAddressRow text="Authorizer" address={stake.authorizer} />
         <PreAddress address={undefined} />

--- a/src/pages/Staking/StakesTable/StakeNameCell.tsx
+++ b/src/pages/Staking/StakesTable/StakeNameCell.tsx
@@ -18,7 +18,7 @@ const StakeNameCell: FC<StakeCellProps & { index: number }> = ({
   return (
     <Td>
       <HStack>
-        <Circle size="24px" bg={gradient(stake.operator)} />
+        <Circle size="24px" bg={gradient(stake.stakingProvider)} />
         <VStack>
           <Body2>T Stake {index + 1}</Body2>
           <Body3 color={useColorModeValue("gray.500", "gray.300")}>

--- a/src/pages/Staking/StakesTable/index.tsx
+++ b/src/pages/Staking/StakesTable/index.tsx
@@ -32,7 +32,7 @@ const StakesTable: FC<StakingTableProps> = ({ stakes }) => {
         <Tbody>
           {stakes.map((stake, i) => {
             return (
-              <Tr key={stake.operator}>
+              <Tr key={stake.stakingProvider}>
                 <StakeNameCell stake={stake} index={i} />
                 <StakeAddressesCell stake={stake} />
                 <StakeBalanceCell stake={stake} />

--- a/src/store/staking/stakingSlice.ts
+++ b/src/store/staking/stakingSlice.ts
@@ -67,11 +67,11 @@ export const stakingSlice = createSlice({
       state,
       action: PayloadAction<UpdateStakeAmountActionPayload>
     ) => {
-      const { operator, amount, increaseOrDecrease } = action.payload
+      const { stakingProvider, amount, increaseOrDecrease } = action.payload
 
       const stakes = state.stakes
       const stakeIdxToUpdate = stakes.findIndex(
-        (stake) => stake.operator === operator
+        (stake) => stake.stakingProvider === stakingProvider
       )
 
       const originalStakeAmount = BigNumber.from(

--- a/src/types/staking.ts
+++ b/src/types/staking.ts
@@ -31,7 +31,7 @@ export interface UseStakingState {
 export interface StakeData {
   stakeType: StakeType
   owner: string
-  operator: string
+  stakingProvider: string
   beneficiary: string
   authorizer: string
   blockNumber: number
@@ -45,7 +45,7 @@ export interface StakeData {
 export interface OperatorStakedEvent {
   stakeType: number
   owner: string
-  operator: string
+  stakingProvider: string
   beneficiary: string
   authorizer: string
   amount: BigNumberish
@@ -58,7 +58,7 @@ export type OperatorStakedActionPayload = OperatorStakedEvent &
   >
 
 export type UpdateStakeAmountActionPayload = {
-  operator: string
+  stakingProvider: string
   amount: string | number
   increaseOrDecrease: "increase" | "decrease"
 }

--- a/src/web3/hooks/useTopupTransaction.ts
+++ b/src/web3/hooks/useTopupTransaction.ts
@@ -8,7 +8,7 @@ import { useTStakingAllowance } from "./useTStakingAllowance"
 
 interface TopupRequest {
   amount: string | number
-  operator: string
+  stakingProvider: string
 }
 
 export const useTopupTransaction = (
@@ -26,13 +26,13 @@ export const useTopupTransaction = (
   const allowance = useTStakingAllowance()
 
   const topup = useCallback(
-    async ({ amount, operator }: TopupRequest) => {
+    async ({ amount, stakingProvider }: TopupRequest) => {
       const isApprovedForAmount = BigNumber.from(amount).lte(allowance)
       if (!isApprovedForAmount) {
         await approve(amount.toString())
       }
 
-      await sendTransaction(operator, amount)
+      await sendTransaction(stakingProvider, amount)
     },
     [sendTransaction, stakingContract?.address, allowance, approve]
   )

--- a/src/web3/hooks/useUnstakeTransaction.ts
+++ b/src/web3/hooks/useUnstakeTransaction.ts
@@ -5,7 +5,7 @@ import { useTStakingContract } from "./useTStakingContract"
 
 interface UnstakeRequest {
   amount: string | number
-  operator: string
+  stakingProvider: string
 }
 
 const useUnstakeTransaction = (
@@ -20,8 +20,8 @@ const useUnstakeTransaction = (
   )
 
   const unstake = useCallback(
-    async ({ amount, operator }: UnstakeRequest) => {
-      await sendTransaction(operator, amount)
+    async ({ amount, stakingProvider }: UnstakeRequest) => {
+      await sendTransaction(stakingProvider, amount)
     },
     [sendTransaction, stakingContract?.address]
   )


### PR DESCRIPTION
Ref: threshold-network/solidity-contracts#72
Ref: threshold-network/solidity-contracts#67

The `OperatorStaked` event has been renamed to `Staked`. Also renamed
the `operator` to `stakingProvider`. This PR does not include
changes in the UI- only renames variables to keep consistency with the
`TTokenStaking` contract.