### PR TITLE
Add "Not found" route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,6 +118,7 @@ const Routing = () => {
       <Route path="*" element={<Layout />}>
         <Route index element={<Navigate to="overview" />} />
         {pages.map(renderPageComponent)}
+        <Route path="*" element={<Navigate to="overview" />} />
       </Route>
     </Routes>
   )


### PR DESCRIPTION
When no other route matches the URL, we want to redirect uesers to an
overview page and render a "not found" route using path="*". This route
will match any URL, but will have the weakest precedence so the router
will only pick it if no other routes match.