### PR TITLE
Ignore `external` directory in git and linters

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 storybook-static
 cypress/fixtures
 cypress/plugins
+external/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Generated
 build/
 dist/
+external/
 
 # Storybook
 storybook-static

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 storybook-static
 cypress/fixtures
 cypress/plugins
+external


### PR DESCRIPTION
An `external/npm/@keep-network/keep-core/artifacts` directory is created
every time the `threshold-network/solidity-contracts` dependency is
installed. This is due to a workaround in
`threshold-network/solidity-contracts` which allows us to use contracts
which come from different repos and share the same name. Creation of
the `external` folder is a by-product of that. We don't need to track
changes in that folder or run linters on its files.