### PR TITLE
Dont use unauthenticated git protocol

### DIFF
--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -36,6 +36,14 @@ jobs:
           node-version: "16"
           cache: "yarn"
 
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next step has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Resolve latest contracts
         run: |
           yarn upgrade \
@@ -68,6 +76,14 @@ jobs:
         with:
           node-version: "16"
           cache: "yarn"
+
+      # We need this step because the `@keep-network/tbtc` which we update in
+      # next step has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+      # downloads one of its sub-dependencies via unathenticated `git://`
+      # protocol. That protocol is no longer supported. Thanks to this step
+      # `https://` is used instead of `git://`.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
 
       - name: Resolve latest ropsten contracts
         run: |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ yarn upgrade @threshold-network/solidity-contracts@ropsten \
   @keep-network/coverage-pools@ropsten
 ```
 
+**NOTE:** The `token-dashboard` package contains an indirect dependency to
+`@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
+via unathenticated `git://` protocol. That protocol is no longer supported by
+GitHub. This means that in certain situations installation of the package or
+update of its dependencies using Yarn may result in `The unauthenticated git protocol on port 9418 is no longer supported` error.
+
+As a workaround, we advise changing Git configuration to use `https://` protocol
+instead of `git://` by executing:
+
+```
+git config --global url."https://".insteadOf git://
+```
+
 ## Run T dapp
 
 `yarn start`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,7 +1448,7 @@
   resolved "https://registry.yarnpkg.com/@celo/utils/-/utils-0.1.11.tgz#c35e3b385091fc6f0c0c355b73270f4a8559ad38"
   integrity sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==
   dependencies:
-    "@umpirsky/country-list" "git://github.com/umpirsky/country-list#05fda51"
+    "@umpirsky/country-list" "git+https://github.com/umpirsky/country-list#05fda51"
     bigi "^1.1.0"
     bignumber.js "^9.0.0"
     bip32 "2.0.5"
@@ -5427,9 +5427,9 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@umpirsky/country-list@git://github.com/umpirsky/country-list#05fda51":
+"@umpirsky/country-list@git+https://github.com/umpirsky/country-list#05fda51":
   version "1.0.0"
-  resolved "git://github.com/umpirsky/country-list#05fda51cd97b3294e8175ffed06104c44b3c71d7"
+  resolved "git+https://github.com/umpirsky/country-list#05fda51cd97b3294e8175ffed06104c44b3c71d7"
 
 "@walletconnect/browser-utils@^1.7.1":
   version "1.7.1"


### PR DESCRIPTION
GitHub is no longer allowing for referencing the dependencies using
`git://` protocol. Instead we can use `git+https://`.

We're changing occurrences of `git://` in the `yarn.lock` and
adding a step to the `dashboard-ci.yaml` workflow which configures git
to download files using `https://` protocol.

This prevens us from getting `The unauthenticated git protocol
on port 9418 is no longer supported.` error.