### PR TITLE
Add cron to `Token Dashboard / CI` workflow

### DIFF
--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -1,6 +1,8 @@
 name: Token Dashboard / CI
 
 on:
+  schedule:
+    - cron: "0 0 * * *"
   push:
     branches:
       - main


### PR DESCRIPTION
Adding a cron which makes the job execute every day at `0:00` UTC. This
may allow us to spot some problems earlier.