### PR TITLE
🔗 🔄 ✍️  Update links for PRE staking docs

### DIFF
--- a/src/enums/externalHref.ts
+++ b/src/enums/externalHref.ts
@@ -3,7 +3,7 @@ export enum ExternalHref {
   thresholdDiscord = "https://discord.gg/WXK9PC6SRF",
   metamaskHomePage = "https://metamask.io/",
   stakingContractLeanMore = "https://github.com/threshold-network/solidity-contracts/issues/53",
-  preNodeSetup = "https://interim-pre-application-docs.readthedocs.io/en/latest/",
-  preStakingProvider = "https://interim-pre-application-docs.readthedocs.io/en/latest/node_operation/node_providers.html",
+  preNodeSetup = "https://docs.nucypher.com/en/latest/pre_application/overview.html",
+  preStakingProvider = "https://docs.nucypher.com/en/latest/pre_application/overview.html#staking-provider",
   exchangeRateLearnMore = "https://blog.threshold.network/threshold-launch/",
 }


### PR DESCRIPTION
Update urls for PRE staking docs.

Docs used before: [https://interim-pre-application-docs.readthedocs.io/en/latest/index.html](https://interim-pre-application-docs.readthedocs.io/en/latest/index.html)

Docs that will be used now: [https://docs.nucypher.com/en/latest/pre_application/overview.html](https://docs.nucypher.com/en/latest/pre_application/overview.html)