### PR TITLE
[Backport] Fix upgrade flow

### DIFF
--- a/src/components/NumberInput/index.tsx
+++ b/src/components/NumberInput/index.tsx
@@ -10,9 +10,12 @@ export interface NumberInputValues {
   floatValue: number
 }
 
-const NumberInput: FC<
-  InputProps & { onValueChange: (values: NumberInputValues) => void }
-> = (props) => {
+export type NumberInputProps = InputProps & {
+  onValueChange: (values: NumberInputValues) => void
+  decimalScale?: number
+}
+
+const NumberInput: FC<NumberInputProps> = (props) => {
   const { field: css } = useMultiStyleConfig("Input", props)
 
   return (
@@ -20,6 +23,7 @@ const NumberInput: FC<
     <ChakraWrapper
       allowLeadingZeros={false}
       thousandSeparator
+      decimalScale={props.decimalScale}
       __css={css}
       {...props}
     />

--- a/src/components/TokenBalanceInput/index.tsx
+++ b/src/components/TokenBalanceInput/index.tsx
@@ -10,10 +10,15 @@ import {
 } from "@chakra-ui/react"
 import { createIcon } from "@chakra-ui/icons"
 import { formatUnits, parseUnits } from "@ethersproject/units"
-import NumberInput, { NumberInputValues } from "../NumberInput"
+import NumberInput, {
+  NumberInputValues,
+  NumberInputProps,
+} from "../NumberInput"
 import { Body3 } from "../Typography"
 
-export interface TokenBalanceInputProps extends InputProps {
+export interface TokenBalanceInputProps
+  extends InputProps,
+    Omit<NumberInputProps, "onValueChange"> {
   icon: ReturnType<typeof createIcon>
   max: number | string
   amount?: string | number

--- a/src/components/UpgradeCard/index.tsx
+++ b/src/components/UpgradeCard/index.tsx
@@ -6,6 +6,7 @@ import NuLight from "../../static/icons/NuLight"
 import { useTokenBalance } from "../../hooks/useTokenBalance"
 import { Token } from "../../enums"
 import { UpgredableToken } from "../../types"
+import { vendingMachine as vendingMachineConstants } from "../../constants"
 
 export interface UpgradeCardProps {
   token: UpgredableToken
@@ -40,7 +41,9 @@ const UpgradeCard: FC<UpgradeCardProps> = ({ token, onSubmit }) => {
         setAmount={setAmount}
         max={balance}
         icon={tokenToIconMap[token]}
-        decimalScale={3}
+        decimalScale={
+          vendingMachineConstants.WRAPPED_TOKEN_CONVERSION_PRECISION
+        }
       />
     </UpgradeCardTemplate>
   )

--- a/src/components/UpgradeCard/index.tsx
+++ b/src/components/UpgradeCard/index.tsx
@@ -40,6 +40,7 @@ const UpgradeCard: FC<UpgradeCardProps> = ({ token, onSubmit }) => {
         setAmount={setAmount}
         max={balance}
         icon={tokenToIconMap[token]}
+        decimalScale={3}
       />
     </UpgradeCardTemplate>
   )

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * as vendingMachine from "./vendingMachine"

--- a/src/constants/vendingMachine.ts
+++ b/src/constants/vendingMachine.ts
@@ -1,0 +1,7 @@
+import { BigNumber } from "@ethersproject/bignumber"
+
+const STANDARD_ERC20_DECIMALS = 18
+export const WRAPPED_TOKEN_CONVERSION_PRECISION = 3
+export const FLOATING_POINT_DIVISOR = BigNumber.from(10).pow(
+  BigNumber.from(STANDARD_ERC20_DECIMALS - WRAPPED_TOKEN_CONVERSION_PRECISION)
+)

--- a/src/hooks/useTConvertedAmount.ts
+++ b/src/hooks/useTConvertedAmount.ts
@@ -4,12 +4,9 @@ import { formatUnits } from "@ethersproject/units"
 import numeral from "numeral"
 import { useVendingMachineRatio } from "../web3/hooks/useVendingMachineRatio"
 import { UpgredableToken } from "../types"
+import { vendingMachine } from "../constants"
 
-const WRAPPED_TOKEN_CONVERSION_PRECISION = 3
-const STANDARD_ERC20_DECIMALS = 18
-const FLOATING_POINT_DIVISOR = BigNumber.from(10).pow(
-  BigNumber.from(STANDARD_ERC20_DECIMALS - WRAPPED_TOKEN_CONVERSION_PRECISION)
-)
+const { FLOATING_POINT_DIVISOR } = vendingMachine
 
 export const useTConvertedAmount = (
   token: UpgredableToken,


### PR DESCRIPTION
Backport of: #99 

Vending machines have a hard-coded precision of 3 decimal places, and below that precision any passed amount is ignored for conversion purposes. The problem is that this leaves some "dust" tokens authorized to the vending machine contract, and this makes upgrade calls to fail later since some ERC20 implementations check for this eg. [the NuCypher token](https://github.com/nucypher/nucypher-contracts/blob/main/contracts/contracts/NuCypherToken.sol#L26-L30). To prevent this situation this PR limits the input in the upgrade flow to 3 decimals so a user can't pass the amount to convert below the third decimal position.