### PR TITLE
Add PRE indicators for staking cards

### DIFF
--- a/src/pages/Staking/StakeCard/index.tsx
+++ b/src/pages/Staking/StakeCard/index.tsx
@@ -85,12 +85,24 @@ const StakeCard: FC<{ stake: StakeData }> = ({ stake }) => {
       <Body2 mt="10" mb="4">
         Staking Bonus
       </Body2>
-      <TokenBalance
-        tokenAmount={stake.bonusEligibility.reward}
-        withSymbol
-        tokenSymbol="T"
-        isLarge
-      />
+      <Flex alignItems={"end"}>
+        <TokenBalance
+          tokenAmount={stake.bonusEligibility.reward}
+          withSymbol
+          tokenSymbol="T"
+          isLarge
+        />
+        {!stake.bonusEligibility.hasPREConfigured && (
+          <>
+            <Badge colorScheme={"red"} variant="solid" size="medium" ml="3">
+              missing PRE
+            </Badge>
+            <Badge colorScheme={"red"} variant="solid" size="medium" ml="3">
+              low PRE funds
+            </Badge>
+          </>
+        )}
+      </Flex>
       <Divider mb="0" />
       {hasLegacyStakes ? (
         <BalanceTree stake={stake} />

--- a/src/pages/Staking/StakeCard/index.tsx
+++ b/src/pages/Staking/StakeCard/index.tsx
@@ -94,10 +94,10 @@ const StakeCard: FC<{ stake: StakeData }> = ({ stake }) => {
         />
         {!stake.bonusEligibility.hasPREConfigured && (
           <>
-            <Badge colorScheme={"red"} variant="solid" size="medium" ml="3">
+            <Badge bg={"red.400"} variant="solid" size="medium" ml="3">
               missing PRE
             </Badge>
-            <Badge colorScheme={"red"} variant="solid" size="medium" ml="3">
+            <Badge bg={"red.400"} variant="solid" size="medium" ml="3">
               low PRE funds
             </Badge>
           </>

--- a/src/theme/Badge.ts
+++ b/src/theme/Badge.ts
@@ -26,7 +26,7 @@ export const Badge = {
     solid: (props: any) => {
       return {
         color: "white",
-        backgroundColor: getColorFromProps(props, 500, "black"),
+        backgroundColor: props.bg || getColorFromProps(props, 500, "black"),
       }
     },
     outline: (props: any) => {
@@ -48,7 +48,7 @@ export const Badge = {
       )(props.theme)
 
       return {
-        backgroundColor: mode(lightModeBg, darkModeBg)(props),
+        backgroundColor: props.bg || mode(lightModeBg, darkModeBg)(props),
         color: mode(lightModeColor, darkModeColor)(props),
       }
     },


### PR DESCRIPTION
Changes:

- adds "MISSING PRE" and "LOW PRE FUNDS" indicator if the PRE is not properly set up for the given stake
- adds a possibility to change background color of a Badge component for specific variants through `bg` property