### PR TITLE
Fix `MAX` amount btn in `TokenBalanceInput` component

### DIFF
--- a/src/components/TokenBalanceInput/index.tsx
+++ b/src/components/TokenBalanceInput/index.tsx
@@ -13,10 +13,13 @@ import {
 } from "@chakra-ui/react"
 import { createIcon } from "@chakra-ui/icons"
 import { formatUnits, parseUnits } from "@ethersproject/units"
+import { Zero } from "@ethersproject/constants"
+import { BigNumber } from "@ethersproject/bignumber"
 import NumberInput, {
   NumberInputValues,
   NumberInputProps,
 } from "../NumberInput"
+import { web3 as web3Constants } from "../../constants"
 
 export interface TokenBalanceInputProps
   extends InputProps,
@@ -59,7 +62,20 @@ const TokenBalanceInput: FC<TokenBalanceInputProps> = ({
   })
 
   const setToMax = () => {
-    _setAmount(formatUnits(max))
+    let remainder = Zero
+    const { decimalScale } = inputProps
+    if (
+      decimalScale &&
+      decimalScale > 0 &&
+      decimalScale < web3Constants.STANDARD_ERC20_DECIMALS
+    ) {
+      remainder = BigNumber.from(max).mod(
+        BigNumber.from(10).pow(
+          web3Constants.STANDARD_ERC20_DECIMALS - decimalScale
+        )
+      )
+    }
+    _setAmount(formatUnits(BigNumber.from(max).sub(remainder)))
     setAmount(valueRef.current)
   }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * as vendingMachine from "./vendingMachine"
 export * as stakingBonus from "./stakingBonus"
+export * as web3 from "./web3"

--- a/src/constants/vendingMachine.ts
+++ b/src/constants/vendingMachine.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "@ethersproject/bignumber"
+import { STANDARD_ERC20_DECIMALS } from "./web3"
 
-const STANDARD_ERC20_DECIMALS = 18
 export const WRAPPED_TOKEN_CONVERSION_PRECISION = 3
 export const FLOATING_POINT_DIVISOR = BigNumber.from(10).pow(
   BigNumber.from(STANDARD_ERC20_DECIMALS - WRAPPED_TOKEN_CONVERSION_PRECISION)

--- a/src/constants/web3.ts
+++ b/src/constants/web3.ts
@@ -1,0 +1,1 @@
+export const STANDARD_ERC20_DECIMALS = 18


### PR DESCRIPTION
If the user clicks `MAX` button in input, the component doesn't limit the
value to decimal scale and passes to a submit function the whole amount.
For example:
- the input in a form is limited to 3 decimals,
- a user has `2.123456789` T tokens,
- a user clicks `MAX` amount,
- a component passes the `2.123456789` value but should `2.123`.

This PR fixes this bug.