### PR TITLE
Change argument used to deploy keep-core

### DIFF
--- a/scripts/start_dashboard.sh
+++ b/scripts/start_dashboard.sh
@@ -83,7 +83,7 @@ fi
 
 printf "${LOG_START}Migrating contracts for keep-core...${LOG_END}"
 cd "$KEEP_CORE_PATH"
-./scripts/install.sh --network local --contracts-only
+./scripts/install.sh --network local --skip-client-build
 cd "$KEEP_CORE_SOL_PATH"
 yarn link
 


### PR DESCRIPTION
Change argument used to deplo `keep-core` in `start_dahsboard.sh` script.

Tha argument name was changed from `--contracts-only` to `--skip-client-build`.

Please see: https://github.com/keep-network/keep-core/pull/3026