### PR TITLE
Use `1.0.1-ropsten.0` package of cov-pools during deploy on Ropsten

### DIFF
--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -62,7 +62,7 @@ jobs:
             @keep-network/keep-core \
             @keep-network/keep-ecdsa \
             @keep-network/tbtc \
-            @keep-network/coverage-pools
+            @keep-network/coverage-pools@1.0.1-ropsten.0
 
       - name: Run postinstall script
         # `yarn upgrade` doesn't trigger the `postinstall` script.
@@ -107,7 +107,7 @@ jobs:
             @keep-network/keep-core@ropsten \
             @keep-network/keep-ecdsa@ropsten \
             @keep-network/tbtc@ropsten \
-            @keep-network/coverage-pools@ropsten
+            @keep-network/coverage-pools@1.0.1-ropsten.0
 
       - name: Run postinstall script
         # `yarn upgrade` doesn't trigger the `postinstall` script.


### PR DESCRIPTION
The `@keep-network/coverage-pools@1.0.1-ropsten.0` package that we want
to use for deployment on Ropsten is not tagged as `ropsten` (as there are
higher-versioned packages currently in the NPM registry). We need to
explicitly provide the version that we want to use.