### PR TITLE
Deploy to GCP bucket after manual dispatch of workflow

### DIFF
--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -144,9 +144,12 @@ jobs:
               body: 'Preview uploaded to https://preview.dashboard.test.threshold.network/${{ github.head_ref }}/index.html.'
             })
 
-      # A push event is triggered on main branch merge; deploy to testnet bucket.
+      # A push event is triggered on main branch merge; deploy to testnet
+      # bucket. Also triggered by manual dispatch.
       - name: Deploy to GCP bucket
-        if: github.event_name == 'push'
+        if: |
+          github.event_name == 'push'
+          || github.event_name == 'workflow_dispatch'
         uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}

--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -145,11 +145,12 @@ jobs:
             })
 
       # A push event is triggered on main branch merge; deploy to testnet
-      # bucket. Also triggered by manual dispatch.
+      # bucket. Also triggered by manual dispatch from `main` branch.
       - name: Deploy to GCP bucket
         if: |
           github.event_name == 'push'
-          || github.event_name == 'workflow_dispatch'
+          || (github.event_name == 'workflow_dispatch'
+          && github.ref == 'refs/heads/main')
         uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
           service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}


### PR DESCRIPTION
So far the step publishing the T dashboard to
`dashboard.test.threshold.network` GCP bucket was executed only when new
changes were being introduced to `main` branch.
There may be cases when we want to re-deploy T dashboard on Testnet
without pushing anything to `main`. This may happen when there's a
change in the dependecncies of the project that we want to see reflected
in the dashboard. To make such deploy possible, we're allowing for
execution of `Deploy to GCP bucket` step for 'workflow_dispatch' event.