### PR TITLE
Fix keep-core deployment

### DIFF
--- a/scripts/start_dashboard.sh
+++ b/scripts/start_dashboard.sh
@@ -83,7 +83,7 @@ fi
 
 printf "${LOG_START}Migrating contracts for keep-core...${LOG_END}"
 cd "$KEEP_CORE_PATH"
-./scripts/install_keep_core_v1.sh --network local --contracts-only
+./scripts/install-v1.sh --network local
 cd "$KEEP_CORE_SOL_PATH"
 yarn link
 

--- a/scripts/start_dashboard.sh
+++ b/scripts/start_dashboard.sh
@@ -83,7 +83,7 @@ fi
 
 printf "${LOG_START}Migrating contracts for keep-core...${LOG_END}"
 cd "$KEEP_CORE_PATH"
-./scripts/install.sh --network local --skip-client-build
+./scripts/install_keep_core_v1.sh --network local --contracts-only
 cd "$KEEP_CORE_SOL_PATH"
 yarn link
 


### PR DESCRIPTION
After the changes in `install.sh` script in `keep-core` repo we restore the old
script as a `install_keep_core_v1.sh` file so we have to make appropiate changes
in `start_dashbaord.sh` file.

Depends on https://github.com/keep-network/keep-core/pull/3100