### PR TITLE
Extracts the stake type to a util for reuse in other components

### DIFF
--- a/src/pages/Staking/StakeCard/HeaderTitle.tsx
+++ b/src/pages/Staking/StakeCard/HeaderTitle.tsx
@@ -1,22 +1,17 @@
 import { FC } from "react"
 import { StakeData } from "../../../types/staking"
-import { StakeType } from "../../../enums"
 import NotificationPill from "../../../components/NotificationPill"
 import { LabelSm } from "@threshold-network/components"
+import { getStakeType } from "../../../utils/getStakeType"
 
 export const StakeCardHeaderTitle: FC<{ stake: StakeData | null }> = ({
   stake,
 }) => {
-  const stakeType = !stake
-    ? ""
-    : stake.stakeType === StakeType.NU || stake.stakeType === StakeType.KEEP
-    ? ` - legacy ${StakeType[stake.stakeType]}`
-    : " - native"
   return (
     <>
       <NotificationPill colorScheme="brand" mr="2" variant="gradient" />
       <LabelSm textTransform="uppercase" mr="auto">
-        stake{stakeType}
+        stake{getStakeType(stake)}
       </LabelSm>
     </>
   )

--- a/src/utils/getStakeType.ts
+++ b/src/utils/getStakeType.ts
@@ -1,7 +1,7 @@
 import { StakeData } from "../types"
 import { StakeType } from "../enums"
 
-export const generateStakeName = (stake?: StakeData): string => {
+export const getStakeType = (stake?: StakeData | null): string => {
   return !stake
     ? ""
     : stake.stakeType === StakeType.NU || stake.stakeType === StakeType.KEEP

--- a/src/utils/getStakeType.ts
+++ b/src/utils/getStakeType.ts
@@ -1,0 +1,10 @@
+import { StakeData } from "../types"
+import { StakeType } from "../enums"
+
+export const generateStakeName = (stake?: StakeData): string => {
+  return !stake
+    ? ""
+    : stake.stakeType === StakeType.NU || stake.stakeType === StakeType.KEEP
+    ? ` - legacy ${StakeType[stake.stakeType]}`
+    : " - native"
+}


### PR DESCRIPTION
There are some new designs that require named stakes. This PR adds a util for generating the "stake type" that is used for naming them.