### PR TITLE
Update dashboard-ci.yaml with tbtc-v2 packages

### DIFF
--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -114,7 +114,7 @@ jobs:
             @keep-network/tbtc@goerli \
             @keep-network/coverage-pools@goerli \
             @keep-network/tbtc-v2@goerli \
-            @keep-network/tbtc-v2.ts@goerli
+            @keep-network/tbtc-v2.ts
 
       - name: Run postinstall script
         # `yarn upgrade` doesn't trigger the `postinstall` script.

--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "14"
           cache: "yarn"
 
       # This step forces Git to download dependencies using `https://` protocol,
@@ -62,7 +62,9 @@ jobs:
             @keep-network/keep-core \
             @keep-network/keep-ecdsa \
             @keep-network/tbtc \
-            @keep-network/coverage-pools
+            @keep-network/coverage-pools \
+            @keep-network/tbtc-v2 \
+            @keep-network/tbtc-v2.ts
 
       - name: Run postinstall script
         # `yarn upgrade` doesn't trigger the `postinstall` script.
@@ -110,7 +112,9 @@ jobs:
             @keep-network/keep-core@1.8.1-goerli.0 \
             @keep-network/keep-ecdsa@goerli \
             @keep-network/tbtc@goerli \
-            @keep-network/coverage-pools@goerli
+            @keep-network/coverage-pools@goerli \
+            @keep-network/tbtc-v2@goearli \
+            @keep-network/tbtc-v2.ts@goerli
 
       - name: Run postinstall script
         # `yarn upgrade` doesn't trigger the `postinstall` script.

--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -113,7 +113,7 @@ jobs:
             @keep-network/keep-ecdsa@goerli \
             @keep-network/tbtc@goerli \
             @keep-network/coverage-pools@goerli \
-            @keep-network/tbtc-v2@goearli \
+            @keep-network/tbtc-v2@goerli \
             @keep-network/tbtc-v2.ts@goerli
 
       - name: Run postinstall script

--- a/.github/workflows/dashboard-ci.yaml
+++ b/.github/workflows/dashboard-ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "14"
           cache: "yarn"
 
       # We need this step because the `@keep-network/tbtc` which we update in

--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "14"
           cache: "yarn"
 
       # This step forces Git to download dependencies using `https://` protocol,


### PR DESCRIPTION
There are problems with installing tbtc-v2 and tbtc-v2.ts packages using
node v16.  Because of that we decided to change the version of node in
dashboard-ci.yaml to 14 and we also upgrade those two libs in 
`resolve latest contracts` and `resolve latest goerli contracts` steps.

We also change the node version to 14 in `dashboard-mainnet.yaml` file

More info: https://github.com/threshold-network/token-dashboard/pull/120#issuecomment-1210665779