### PR TITLE
Manual approval of deployment to dashboard.test.threshold.network

### DIFF
--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -1,6 +1,13 @@
 name: Deploy to testnet bucket
 description: "Build and deploy to testnet bucket"
 inputs:
+  # Currently wthe action only supports `environment` = `goerli`.
+  environment:
+    description: >
+      The environment on which the action should be used. For example `goerli`.
+      Will be used to deterine environment variables and decide which legacy
+      packages should be used for building.
+    required: true
   ethHostnameHttp:
     description: The http ETH hostname
     required: true
@@ -18,7 +25,10 @@ inputs:
     description: Upstream builds (required if `useUpstreamBuilds==true`)
     required: false
   dependentPackagesTag:
-    description: Tag which should be used to pull packages with contracts (required if `useUpstreamBuilds==false`). For example `goerli`.
+    description: >
+      Tag which should be used to pull latest non-legacy `threshold-network` and
+      `keep-network` packages with contracts (required if
+      `useUpstreamBuilds==false`). For example `dappdevgoerli`.
     required: false
   preview:
     description: True if the code should be pushed to the preview bucket
@@ -65,21 +75,22 @@ runs:
           echo "::set-output name=threshold-contracts-version::${{ steps.upstream-builds-query.outputs.threshold-contracts-version }}"
         fi
 
-    # We provide explicit version of the `keep-core` package, because using
-    # `goerli` tag results in `expected manifest` error - probably caused by
-    # bug in Yarn: https://github.com/yarnpkg/yarn/issues/4731.
+    # Currently we only support `environment` = `goerli`. We provide explicit
+    # version of the `keep-core` package, because using `goerli` tag results in
+    # `expected manifest` error - probably caused by bug in Yarn:
+    # https://github.com/yarnpkg/yarn/issues/4731. 
 
     # TODO: Add upgrade of @keep-network/random-beacon, @keep-network/ecdsa,
     # @keep-network/tbtc-v2 once they'll be added as dashboard's dependencies.
-    - name: Resolve latest goerli contracts
+    - name: Resolve contracts
       shell: bash
       run: |
         yarn upgrade \
           @threshold-network/solidity-contracts@${{ steps.set-packages-versions.outputs.threshold-contracts-version }} \
           @keep-network/keep-core@1.8.1-goerli.0 \
-          @keep-network/keep-ecdsa@goerli \
-          @keep-network/tbtc@goerli \
-          @keep-network/coverage-pools@goerli
+          @keep-network/keep-ecdsa@${{ inputs.environment }} \
+          @keep-network/tbtc@${{ inputs.environment }} \
+          @keep-network/coverage-pools@${{ inputs.environment }}
 
     - name: Run postinstall script
       shell: bash
@@ -89,7 +100,7 @@ runs:
     - name: Load environment variables
       uses: keep-network/ci/actions/load-env-variables@v2
       with:
-        environment: goerli
+        environment: ${{ inputs.environment }} 
 
     - name: Build
       if: inputs.preview == 'true'

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -34,6 +34,9 @@ inputs:
     description: True if the code should be pushed to the preview bucket
     required: true
     default: "false"
+  bucketName:
+    description: The name of the bucket where code wil be deployed.
+    required: true
 
 runs:
   using: "composite"
@@ -112,15 +115,17 @@ runs:
         ETH_HOSTNAME_HTTP: ${{ inputs.ethHostnameHttp }}
         ETH_HOSTNAME_WS: ${{ inputs.ethHostnameWs }}
 
-    - name: Deploy PR preview to GCP
-      if: inputs.preview == 'true'
+    - name: Deploy to GCP
       uses: thesis/gcp-storage-bucket-action@v3.1.0
       with:
         service-key: ${{ inputs.gcpServiceKey }}
         project: ${{ env.GOOGLE_PROJECT_ID }}
-        bucket-name: preview.dashboard.test.threshold.network
+        bucket-name: ${{ inputs.bucketName }}
         bucket-path: ${{ github.head_ref }}
         build-folder: build
+        set-website: true
+        home-page-path: index.html
+        error-page-path: index.html
 
     - name: Post preview URL to PR
       if: inputs.preview == 'true'
@@ -131,17 +136,5 @@ runs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: 'Preview uploaded to https://preview.dashboard.test.threshold.network/${{ github.head_ref }}/index.html.'
+            body: 'Preview uploaded to ${{ inputs.bucketName }}/${{ github.head_ref }}/index.html.'
           })
-
-    - name: Deploy to GCP bucket
-      if: inputs.preview == 'false'
-      uses: thesis/gcp-storage-bucket-action@v3.1.0
-      with:
-        service-key: ${{ inputs.gcpServiceKey }}
-        project: ${{ env.GOOGLE_PROJECT_ID }}
-        bucket-name: dashboard.test.threshold.network
-        build-folder: build
-        set-website: true
-        home-page-path: index.html
-        error-page-path: index.html

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -1,5 +1,5 @@
-name: Deploy to testnet bucket
-description: "Build and deploy to testnet bucket"
+name: Deploy to a GCP Bucket
+description: "Builds and deploys to a Google Cloud Storage Bucket"
 inputs:
   # Currently wthe action only supports `environment` = `goerli`.
   environment:
@@ -8,14 +8,11 @@ inputs:
       Will be used to deterine environment variables and decide which legacy
       packages should be used for building.
     required: true
-  ethHostnameHttp:
-    description: The http ETH hostname
+  ethUrlHttp:
+    description: The HTTP ETH API URL
     required: true
-  ethHostnameWs:
-    description: The ws ETH hostname
-    required: true
-  gcpServiceKey:
-    description: JSON key for Google Cloud Platform service account
+  ethUrlWS:
+    description: The WebSocket ETH API URL
     required: true
   useUpstreamBuilds:
     description: True if the upstream builds should be used
@@ -30,13 +27,16 @@ inputs:
       `keep-network` packages with contracts (required if
       `useUpstreamBuilds==false`). For example `dappdevgoerli`.
     required: false
+  gcpServiceKey:
+    description: JSON key for Google Cloud Platform service account
+    required: true
+  bucketName:
+    description: The name of the bucket where code wil be deployed.
+    required: true
   preview:
     description: True if the code should be pushed to the preview bucket
     required: true
     default: "false"
-  bucketName:
-    description: The name of the bucket where code wil be deployed.
-    required: true
 
 runs:
   using: "composite"
@@ -112,8 +112,8 @@ runs:
       env:
         PUBLIC_URL: /${{ github.head_ref }}
         CHAIN_ID: ${{ env.NETWORK_ID }}
-        ETH_HOSTNAME_HTTP: ${{ inputs.ethHostnameHttp }}
-        ETH_HOSTNAME_WS: ${{ inputs.ethHostnameWs }}
+        ETH_HOSTNAME_HTTP: ${{ inputs.ethUrlHttp }}
+        ETH_HOSTNAME_WS: ${{ inputs.ethUrlWS }}
 
     - name: Deploy to GCP
       uses: thesis/gcp-storage-bucket-action@v3.1.0

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -9,17 +9,17 @@ inputs:
       packages should be used for building.
     required: true
   ethUrlHttp:
-    description: The HTTP ETH API URL
+    description: The HTTP ETH API URL.
     required: true
   ethUrlWS:
-    description: The WebSocket ETH API URL
+    description: The WebSocket ETH API URL.
     required: true
   useUpstreamBuilds:
-    description: True if the upstream builds should be used
+    description: True if the upstream builds should be used.
     required: true
     default: "false"
   upstreamBuilds:
-    description: Upstream builds (required if `useUpstreamBuilds==true`)
+    description: Upstream builds (required if `useUpstreamBuilds==true`).
     required: false
   dependentPackagesTag:
     description: >
@@ -28,13 +28,13 @@ inputs:
       `useUpstreamBuilds==false`). For example `dappdevgoerli`.
     required: false
   gcpServiceKey:
-    description: JSON key for Google Cloud Platform service account
+    description: JSON key for Google Cloud Platform service account.
     required: true
   bucketName:
     description: The name of the bucket where code wil be deployed.
     required: true
   preview:
-    description: True if the code should be pushed to the preview bucket
+    description: True if the code should be pushed to the preview bucket.
     required: true
     default: "false"
 
@@ -81,7 +81,7 @@ runs:
     # Currently we only support `environment` = `goerli`. We provide explicit
     # version of the `keep-core` package, because using `goerli` tag results in
     # `expected manifest` error - probably caused by bug in Yarn:
-    # https://github.com/yarnpkg/yarn/issues/4731. 
+    # https://github.com/yarnpkg/yarn/issues/4731.
 
     # TODO: Add upgrade of @keep-network/random-beacon, @keep-network/ecdsa,
     # @keep-network/tbtc-v2 once they'll be added as dashboard's dependencies.
@@ -103,7 +103,7 @@ runs:
     - name: Load environment variables
       uses: keep-network/ci/actions/load-env-variables@v2
       with:
-        environment: ${{ inputs.environment }} 
+        environment: ${{ inputs.environment }}
 
     - name: Build
       if: inputs.preview == 'true'

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -1,0 +1,133 @@
+name: Deploy to testnet bucket
+description: "Build and deploy to testnet bucket"
+inputs:
+  ethHostnameHttp:
+    description: The http ETH hostname
+    required: true
+  ethHostnameWs:
+    description: The ws ETH hostname
+    required: true
+  gcpServiceKey:
+    description: JSON key for Google Cloud Platform service account
+    required: true
+  gcpProject:
+    description: Google Cloud Platform project
+    required: true
+  useUpstreamBuilds:
+    description: True if the upstream builds should be used
+    required: true
+    default: "false"
+  upstreamBuilds:
+    description: Upstream builds (required if `useUpstreamBuilds==true`)
+    required: false
+  dependentPackagesTag:
+    description: Tag which should be used to pull packages with contracts (required if `useUpstreamBuilds==false`). For example `goerli`.
+    required: false
+  preview:
+    description: True if the code should be pushed to the preview bucket
+    required: true
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: "14"
+        cache: "yarn"
+
+    # We need this step because the `@keep-network/tbtc` which we update in
+    # next step has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
+    # downloads one of its sub-dependencies via unathenticated `git://`
+    # protocol. That protocol is no longer supported. Thanks to this step
+    # `https://` is used instead of `git://`.
+    - name: Configure git to don't use unauthenticated protocol
+      shell: bash
+      run: git config --global url."https://".insteadOf git://
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --frozen-lockfile
+
+    - name: Get upstream packages versions
+      if: inputs.upstreamBuilds == 'true'
+      uses: keep-network/ci/actions/upstream-builds-query@v2
+      id: upstream-builds-query
+      with:
+        upstream-builds: ${{ inputs.upstreamBuilds }}
+        query: |
+          threshold-contracts-version = github.com/threshold-network/solidity-contracts#version
+
+    - name: Set packages versions
+      shell: bash
+      id: set-packages-versions
+      run: |
+        if [ ${{ inputs.useUpstreamBuilds }} = 'false' ]; then
+          echo "::set-output name=threshold-contracts-version::${{ inputs.dependentPackagesTag }}"
+        else
+          echo "::set-output name=threshold-contracts-version::${{ steps.upstream-builds-query.outputs.threshold-contracts-version }}"
+        fi
+
+    # We provide explicit version of the `keep-core` package, because using
+    # `goerli` tag results in `expected manifest` error - probably caused by
+    # bug in Yarn: https://github.com/yarnpkg/yarn/issues/4731.
+
+    # TODO: Add upgrade of @keep-network/random-beacon, @keep-network/ecdsa,
+    # @keep-network/tbtc-v2 once they'll be added as dashboard's dependencies.
+    - name: Resolve latest goerli contracts
+      shell: bash
+      run: |
+        yarn upgrade \
+          @threshold-network/solidity-contracts@${{ steps.set-packages-versions.outputs.threshold-contracts-version }} \
+          @keep-network/keep-core@1.8.1-goerli.0 \
+          @keep-network/keep-ecdsa@goerli \
+          @keep-network/tbtc@goerli \
+          @keep-network/coverage-pools@goerli
+
+    - name: Run postinstall script
+      shell: bash
+      # `yarn upgrade` doesn't trigger the `postinstall` script.
+      run: yarn run postinstall
+
+    - name: Build
+      shell: bash
+      run: yarn build
+      env:
+        PUBLIC_URL: /${{ github.head_ref }}
+        CHAIN_ID: "5"
+        ETH_HOSTNAME_HTTP: ${{ inputs.ethHostnameHttp }}
+        ETH_HOSTNAME_WS: ${{ inputs.ethHostnameWs }}
+
+    - name: Deploy PR preview to GCP
+      if: inputs.preview == 'true'
+      uses: thesis/gcp-storage-bucket-action@v3.1.0
+      with:
+        service-key: ${{ inputs.gcpServiceKey }}
+        project: ${{ inputs.gcpProject }}
+        bucket-name: preview.dashboard.test.threshold.network
+        bucket-path: ${{ github.head_ref }}
+        build-folder: build
+
+    - name: Post preview URL to PR
+      if: inputs.preview == 'true'
+      uses: actions/github-script@v5
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Preview uploaded to https://preview.dashboard.test.threshold.network/${{ github.head_ref }}/index.html.'
+          })
+
+    - name: Deploy to GCP bucket
+      if: inputs.preview == 'false'
+      uses: thesis/gcp-storage-bucket-action@v3.1.0
+      with:
+        service-key: ${{ inputs.gcpServiceKey }}
+        project: ${{ inputs.gcpProject }}
+        bucket-name: dashboard.test.threshold.network
+        build-folder: build
+        set-website: true
+        home-page-path: index.html
+        error-page-path: index.html

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -110,6 +110,9 @@ runs:
       shell: bash
       run: yarn build
       env:
+        # `head_ref` variable property is only available when the event that
+        # triggers a workflow run is either pull_request or pull_request_target.
+        # For `workflow_dispatch` and `push`, the `PUBLIC_URL` will resoleve to `/`.`
         PUBLIC_URL: /${{ github.head_ref }}
         CHAIN_ID: ${{ env.NETWORK_ID }}
         ETH_HOSTNAME_HTTP: ${{ inputs.ethUrlHttp }}

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: >
       Tag which should be used to pull latest non-legacy `threshold-network` and
       `keep-network` packages with contracts (required if
-      `useUpstreamBuilds==false`). For example `dappdevgoerli`.
+      `useUpstreamBuilds==false`). For example `dapp-dev-goerli`.
     required: false
   gcpServiceKey:
     description: JSON key for Google Cloud Platform service account.
@@ -125,7 +125,7 @@ runs:
         bucket-name: ${{ inputs.gcpBucketName }}
         bucket-path: ${{ github.head_ref }}
         build-folder: build
-        set-website: true
+        set-website: ${{ inputs.preview == 'false' }}
         home-page-path: index.html
         error-page-path: index.html
 

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -106,7 +106,6 @@ runs:
         environment: ${{ inputs.environment }}
 
     - name: Build
-      if: inputs.preview == 'true'
       shell: bash
       run: yarn build
       env:

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -139,5 +139,5 @@ runs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: 'Preview uploaded to ${{ inputs.bucketName }}/${{ github.head_ref }}/index.html.'
+            body: 'Preview uploaded to https://${{ inputs.bucketName }}/${{ github.head_ref }}/index.html.'
           })

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -10,9 +10,6 @@ inputs:
   gcpServiceKey:
     description: JSON key for Google Cloud Platform service account
     required: true
-  gcpProject:
-    description: Google Cloud Platform project
-    required: true
   useUpstreamBuilds:
     description: True if the upstream builds should be used
     required: true
@@ -89,12 +86,18 @@ runs:
       # `yarn upgrade` doesn't trigger the `postinstall` script.
       run: yarn run postinstall
 
+    - name: Load environment variables
+      uses: keep-network/ci/actions/load-env-variables@v2
+      with:
+        environment: goerli
+
     - name: Build
+      if: inputs.preview == 'true'
       shell: bash
       run: yarn build
       env:
         PUBLIC_URL: /${{ github.head_ref }}
-        CHAIN_ID: "5"
+        CHAIN_ID: ${{ env.NETWORK_ID }}
         ETH_HOSTNAME_HTTP: ${{ inputs.ethHostnameHttp }}
         ETH_HOSTNAME_WS: ${{ inputs.ethHostnameWs }}
 
@@ -103,7 +106,7 @@ runs:
       uses: thesis/gcp-storage-bucket-action@v3.1.0
       with:
         service-key: ${{ inputs.gcpServiceKey }}
-        project: ${{ inputs.gcpProject }}
+        project: ${{ env.GOOGLE_PROJECT_ID }}
         bucket-name: preview.dashboard.test.threshold.network
         bucket-path: ${{ github.head_ref }}
         build-folder: build
@@ -125,7 +128,7 @@ runs:
       uses: thesis/gcp-storage-bucket-action@v3.1.0
       with:
         service-key: ${{ inputs.gcpServiceKey }}
-        project: ${{ inputs.gcpProject }}
+        project: ${{ env.GOOGLE_PROJECT_ID }}
         bucket-name: dashboard.test.threshold.network
         build-folder: build
         set-website: true

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -1,7 +1,7 @@
 name: Deploy to a GCP Bucket
 description: "Builds and deploys to a Google Cloud Storage Bucket"
 inputs:
-  # Currently wthe action only supports `environment` = `goerli`.
+  # Currently the action only supports `environment` = `goerli`.
   environment:
     description: >
       The environment on which the action should be used. For example `goerli`.
@@ -30,7 +30,7 @@ inputs:
   gcpServiceKey:
     description: JSON key for Google Cloud Platform service account.
     required: true
-  bucketName:
+  gcpBucketName:
     description: The name of the bucket where code wil be deployed.
     required: true
   preview:
@@ -112,7 +112,7 @@ runs:
       env:
         # `head_ref` variable property is only available when the event that
         # triggers a workflow run is either pull_request or pull_request_target.
-        # For `workflow_dispatch` and `push`, the `PUBLIC_URL` will resoleve to `/`.`
+        # For `workflow_dispatch` and `push`, the `PUBLIC_URL` will resolve to `/`.`
         PUBLIC_URL: /${{ github.head_ref }}
         CHAIN_ID: ${{ env.NETWORK_ID }}
         ETH_HOSTNAME_HTTP: ${{ inputs.ethUrlHttp }}
@@ -123,7 +123,7 @@ runs:
       with:
         service-key: ${{ inputs.gcpServiceKey }}
         project: ${{ env.GOOGLE_PROJECT_ID }}
-        bucket-name: ${{ inputs.bucketName }}
+        bucket-name: ${{ inputs.gcpBucketName }}
         bucket-path: ${{ github.head_ref }}
         build-folder: build
         set-website: true
@@ -139,5 +139,5 @@ runs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: 'Preview uploaded to https://${{ inputs.bucketName }}/${{ github.head_ref }}/index.html.'
+            body: 'Preview uploaded to https://${{ inputs.gcpBucketName }}/${{ github.head_ref }}/index.html.'
           })

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -104,13 +104,13 @@ jobs:
       - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
           environment: goerli
-          ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
-          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          ethUrlHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          ethUrlWS: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           useUpstreamBuilds: true
           dependentPackagesTag: goerli
-          preview: true
+          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           bucketName: preview.dashboard.test.threshold.network
+          preview: true
 
   # This job will be triggered via the `workflow_dispatch` event, as part of the
   # CI flow, which gets triggered manually after changes in the contracts,
@@ -135,13 +135,13 @@ jobs:
       - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
           environment: goerli
-          ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
-          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          ethUrlHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          ethUrlWS: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           useUpstreamBuilds: true
           upstreamBuilds: ${{ github.event.inputs.upstream_builds }}
-          preview: false
+          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           bucketName: dashboard.test.threshold.network
+          preview: false
 
   # This job will be triggered after merges of PRs to the `main` branch. As the
   # triggering is not related to the changes in the contracts / client code, we
@@ -159,10 +159,10 @@ jobs:
       - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
           environment: goerli
-          ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
-          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          ethUrlHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          ethUrlWS: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           useUpstreamBuilds: false
           dependentPackagesTag: goerli
-          preview: false
+          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           bucketName: dashboard.test.threshold.network
+          preview: false

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -105,7 +105,7 @@ jobs:
           environment: goerli
           ethUrlHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           ethUrlWS: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
-          useUpstreamBuilds: true
+          useUpstreamBuilds: false
           dependentPackagesTag: goerli
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           gcpBucketName: preview.dashboard.test.threshold.network

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -110,6 +110,7 @@ jobs:
           useUpstreamBuilds: true
           dependentPackagesTag: goerli
           preview: true
+          bucketName: preview.dashboard.test.threshold.network
 
   # This job will be triggered via the `workflow_dispatch` event, as part of the
   # CI flow, which gets triggered manually after changes in the contracts,
@@ -140,6 +141,7 @@ jobs:
           useUpstreamBuilds: true
           upstreamBuilds: ${{ github.event.inputs.upstream_builds }}
           preview: false
+          bucketName: dashboard.test.threshold.network
 
   # This job will be triggered after merges of PRs to the `main` branch. As the
   # triggering is not related to the changes in the contracts / client code, we
@@ -163,3 +165,4 @@ jobs:
           useUpstreamBuilds: false
           dependentPackagesTag: goerli
           preview: false
+          bucketName: dashboard.test.threshold.network

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -12,7 +12,6 @@ on:
       environment:
         description: "Environment (network) for workflow execution, e.g. `goerli`"
         required: false
-        default: "dev"
       upstream_builds:
         description: "Upstream builds"
         required: false

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -8,6 +8,18 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment (network) for workflow execution, e.g. `goerli`"
+        required: false
+        default: "dev"
+      upstream_builds:
+        description: "Upstream builds"
+        required: false
+      upstream_ref:
+        description: "Git reference to checkout (e.g. branch name)"
+        required: false
+        default: "main"
 
 jobs:
   format:
@@ -80,86 +92,74 @@ jobs:
       # - name: Test
       #   run: yarn test
 
-  build-and-deploy-testnet:
-    name: Deploy to testnet
+  # The code will be published to `https://preview.dashboard.test.threshold.network/${{ github.head_ref }}/index.html.`
+  build-and-deploy-testnet-preview:
+    name: Deploy preview to testnet
     needs: build-and-test
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
-          node-version: "16"
-          cache: "yarn"
+          ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
+          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          gcpProject: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
+          useUpstreamBuilds: true
+          dependentPackagesTag: goerli
+          preview: true
 
-      # We need this step because the `@keep-network/tbtc` which we update in
-      # next step has a dependency to `@summa-tx/relay-sol@2.0.2` package, which
-      # downloads one of its sub-dependencies via unathenticated `git://`
-      # protocol. That protocol is no longer supported. Thanks to this step
-      # `https://` is used instead of `git://`.
-      - name: Configure git to don't use unauthenticated protocol
-        run: git config --global url."https://".insteadOf git://
+  # This job will be triggered via the `workflow_dispatch` event, as part of the
+  # CI flow, which gets triggered manually after changes in the contracts,
+  # client code, etc. As after such changes the manual rotation of the client
+  # pods is needed, we configure the job to use the protected `testnet`
+  # environment. Thanks to this, the job won't start until somebody approves it
+  # in GH Actions.
+  # The code will be published to `https://dashboard.test.threshold.network/index.html.`
+  build-and-deploy-testnet-on-dispatch:
+    name: Deploy to testnet
+    needs: build-and-test
+    if: |
+      github.event_name == 'workflow_dispatch'
+        && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # testnet environment is protected, it requires an approval before execution.
+    environment:
+      name: testnet
+    steps:
+      - uses: actions/checkout@v3
 
-      # We provide explicit version of the `keep-core` package, because using
-      # `goerli` tag results in `expected manifest` error - probably caused by
-      # bug in Yarn: https://github.com/yarnpkg/yarn/issues/4731.
-      - name: Resolve latest goerli contracts
-        run: |
-          yarn upgrade \
-            @threshold-network/solidity-contracts@goerli \
-            @keep-network/keep-core@1.8.1-goerli.0 \
-            @keep-network/keep-ecdsa@goerli \
-            @keep-network/tbtc@goerli \
-            @keep-network/coverage-pools@goerli
-
-      - name: Run postinstall script
-        # `yarn upgrade` doesn't trigger the `postinstall` script.
-        run: yarn run postinstall
-
-      - name: Build
-        run: yarn build
-        env:
-          PUBLIC_URL: /${{ github.head_ref }}
-          CHAIN_ID: 5
-          ETH_HOSTNAME_HTTP: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          ETH_HOSTNAME_WS: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
-
-      # A pull_request event is a PR; deploy to preview testnet bucket.
-      - name: Deploy PR preview to GCP
-        if: github.event_name == 'pull_request'
-        uses: thesis/gcp-storage-bucket-action@v3.1.0
+      - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
-          service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          project: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
-          bucket-name: preview.dashboard.test.threshold.network
-          bucket-path: ${{ github.head_ref }}
-          build-folder: build
+          ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
+          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          gcpProject: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
+          useUpstreamBuilds: true
+          upstreamBuilds: ${{ github.event.inputs.upstream_builds }}
+          preview: false
 
-      - name: Post preview URL to PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v5
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Preview uploaded to https://preview.dashboard.test.threshold.network/${{ github.head_ref }}/index.html.'
-            })
+  # This job will be triggered after merges of PRs to the `main` branch. As the
+  # triggering is not related to the changes in the contracts / client code, we
+  # don't need to rotate the pods and hence don't need to wait with the
+  # execution of workflow for the manual approval.
+  # The code will be published to `https://dashboard.test.threshold.network/index.html.`
+  build-and-deploy-testnet-on-push:
+    name: Deploy to testnet
+    needs: build-and-test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-      # A push event is triggered on main branch merge; deploy to testnet
-      # bucket. Also triggered by manual dispatch from `main` branch.
-      - name: Deploy to GCP bucket
-        if: |
-          github.event_name == 'push'
-          || (github.event_name == 'workflow_dispatch'
-          && github.ref == 'refs/heads/main')
-        uses: thesis/gcp-storage-bucket-action@v3.1.0
+      - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
-          service-key: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          project: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
-          bucket-name: dashboard.test.threshold.network
-          build-folder: build
-          set-website: true
-          home-page-path: index.html
-          error-page-path: index.html
+          ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
+          gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
+          gcpProject: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
+          useUpstreamBuilds: false
+          dependentPackagesTag: goerli
+          preview: false

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -106,7 +106,6 @@ jobs:
           ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          gcpProject: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
           useUpstreamBuilds: true
           dependentPackagesTag: goerli
           preview: true
@@ -136,7 +135,6 @@ jobs:
           ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          gcpProject: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
           useUpstreamBuilds: true
           upstreamBuilds: ${{ github.event.inputs.upstream_builds }}
           preview: false
@@ -159,7 +157,6 @@ jobs:
           ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          gcpProject: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
           useUpstreamBuilds: false
           dependentPackagesTag: goerli
           preview: false

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -108,7 +108,7 @@ jobs:
           useUpstreamBuilds: true
           dependentPackagesTag: goerli
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          bucketName: preview.dashboard.test.threshold.network
+          gcpBucketName: preview.dashboard.test.threshold.network
           preview: true
 
   # This job will be triggered via the `workflow_dispatch` event, as part of the
@@ -139,7 +139,7 @@ jobs:
           useUpstreamBuilds: true
           upstreamBuilds: ${{ github.event.inputs.upstream_builds }}
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          bucketName: dashboard.test.threshold.network
+          gcpBucketName: dashboard.test.threshold.network
           preview: false
 
   # This job will be triggered after merges of PRs to the `main` branch. As the
@@ -163,5 +163,5 @@ jobs:
           useUpstreamBuilds: false
           dependentPackagesTag: goerli
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
-          bucketName: dashboard.test.threshold.network
+          gcpBucketName: dashboard.test.threshold.network
           preview: false

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -92,7 +92,7 @@ jobs:
       # - name: Test
       #   run: yarn test
 
-  # The code will be published to `https://preview.dashboard.test.threshold.network/${{ github.head_ref }}/index.html.`
+  # The code will be published to https://preview.dashboard.test.threshold.network/${{ github.head_ref }}/index.html.
   build-and-deploy-testnet-preview:
     name: Deploy preview to testnet
     needs: build-and-test
@@ -118,7 +118,7 @@ jobs:
   # pods is needed, we configure the job to use the protected `testnet`
   # environment. Thanks to this, the job won't start until somebody approves it
   # in GH Actions.
-  # The code will be published to `https://dashboard.test.threshold.network/index.html.`
+  # The code will be published to https://dashboard.test.threshold.network/index.html.
   build-and-deploy-testnet-on-dispatch:
     name: Deploy to testnet
     needs: build-and-test
@@ -147,7 +147,7 @@ jobs:
   # triggering is not related to the changes in the contracts / client code, we
   # don't need to rotate the pods and hence don't need to wait with the
   # execution of workflow for the manual approval.
-  # The code will be published to `https://dashboard.test.threshold.network/index.html.`
+  # The code will be published to https://dashboard.test.threshold.network/index.html.
   build-and-deploy-testnet-on-push:
     name: Deploy to testnet
     needs: build-and-test

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -103,6 +103,7 @@ jobs:
 
       - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
+          environment: goerli
           ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
@@ -132,6 +133,7 @@ jobs:
 
       - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
+          environment: goerli
           ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
@@ -154,6 +156,7 @@ jobs:
 
       - uses: ./.github/actions/build-and-deploy-to-bucket
         with:
+          environment: goerli
           ethHostnameHttp: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           ethHostnameWs: ${{ secrets.GOERLI_ETH_HOSTNAME_WS }}
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}


### PR DESCRIPTION
We've integrated deployment of the testnet Token Dashboard into our
CI flow (deployment of new goerli packages with contracts triggers
start of the `Dashboard / CI` workflow). But we don't want to start the
dashboard deploy right away, because first the manual restart of the
client nodes is needed. Due to that we're introducing protection of the
`testnet` environment. Jobs which will use this environment will need to
be manually approved in GH Actions run's details. We don't need to halt
the deployment when workflow gets triggered by the merge to `main`,
because this trigger is not related to changes to contracts / client and
there is no need for the rotation of the client pods. This difference in
the need for use of environment protection meant that we needed to split
the `build-and-deploy-testnet` job to two separate jobs (another reason
for that was that we wanted to use `upstream builds` in case of
`workflow_dispatch` trigger). As after the split we would have three
jobs that had quite similar steps, we decided to extract the steps to
a separate action.

Some further optimization of the new action is possible (like adjusting it for the use in the workflow publishing storybook for `components` repo, or in a workflow publishing to mainnet bucket), but I think it can be done in separate PRs.

TODO:
- [x] Make sure that https://github.com/keep-network/ci/pull/32 is merged to `main`
- [x] Set protection for `testnet` environment (@nkuba)
- [ ] Add resolving of `@keep-network/random-beacon`, `@keep-network/ecdsa` and `@keep-network/tbtc-v2` contracts if they'll be added as dashboard's dependencies before merge of this PR (see https://github.com/threshold-network/token-dashboard/pull/120/files)

TODO after the merge:
- [ ] Verify that job `build-and-deploy-testnet-on-push` got executed correctly