### PR TITLE
Specify `bucket-path` when `github.head_ref` is not set

### DIFF
--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -117,13 +117,29 @@ runs:
         ETH_HOSTNAME_HTTP: ${{ inputs.ethUrlHttp }}
         ETH_HOSTNAME_WS: ${{ inputs.ethUrlWS }}
 
+    # We need this step to set correct value of `bucket-path` in the
+    # `cp-storage-bucket-action`. We can't use `${{ github.head_ref }}` directly
+    # there, because then when `head_ref` is empty, the parameter `bucket-path`
+    # is not forwarded to the runner and empty value is assigned to the
+    # `bucket-path` input instead of the default value (`.`). This results in
+    # incorrect passing of docker arguments and setting wrong bucket address.
+    - name: Configure `bucket-path`
+      shell: bash
+      id: set-bucket-path
+      run: |
+        if [ ${{ github.head_ref }} == '' ]; then
+          echo "::set-output name=bucket-path::."
+        else
+          echo "::set-output name=bucket-path::${{ github.head_ref }}"
+        fi
+
     - name: Deploy to GCP
       uses: thesis/gcp-storage-bucket-action@v3.1.0
       with:
         service-key: ${{ inputs.gcpServiceKey }}
         project: ${{ env.GOOGLE_PROJECT_ID }}
         bucket-name: ${{ inputs.gcpBucketName }}
-        bucket-path: ${{ github.head_ref }}
+        bucket-path: ${{ steps.set-bucket-path.outputs.bucket-path }}
         build-folder: build
         set-website: ${{ inputs.preview == 'false' }}
         home-page-path: index.html

--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -31,8 +31,15 @@ inputs:
     description: JSON key for Google Cloud Platform service account.
     required: true
   gcpBucketName:
-    description: The name of the bucket where code wil be deployed.
+    description: The name of the bucket where the code will be deployed.
     required: true
+  gcpBucketPath:
+    description: >
+      The path where in the bucket the code will be deployed. When you don't to
+      put the code in the bucket's subfolder, set `.`. Otherwise provide the
+      path, without leading `./` (for example `subfolder_1/subfolder_2`).
+    required: false
+    default: .
   preview:
     description: True if the code should be pushed to the preview bucket.
     required: true
@@ -106,32 +113,24 @@ runs:
         environment: ${{ inputs.environment }}
 
     - name: Build
+      if: inputs.gcpBucketPath == '.'
       shell: bash
       run: yarn build
       env:
-        # `head_ref` variable property is only available when the event that
-        # triggers a workflow run is either pull_request or pull_request_target.
-        # For `workflow_dispatch` and `push`, the `PUBLIC_URL` will resolve to `/`.`
-        PUBLIC_URL: /${{ github.head_ref }}
+        PUBLIC_URL: /
         CHAIN_ID: ${{ env.NETWORK_ID }}
         ETH_HOSTNAME_HTTP: ${{ inputs.ethUrlHttp }}
         ETH_HOSTNAME_WS: ${{ inputs.ethUrlWS }}
 
-    # We need this step to set correct value of `bucket-path` in the
-    # `cp-storage-bucket-action`. We can't use `${{ github.head_ref }}` directly
-    # there, because then when `head_ref` is empty, the parameter `bucket-path`
-    # is not forwarded to the runner and empty value is assigned to the
-    # `bucket-path` input instead of the default value (`.`). This results in
-    # incorrect passing of docker arguments and setting wrong bucket address.
-    - name: Configure `bucket-path`
+    - name: Build
+      if: inputs.gcpBucketPath != '.'
       shell: bash
-      id: set-bucket-path
-      run: |
-        if [ ${{ github.head_ref }} == '' ]; then
-          echo "::set-output name=bucket-path::."
-        else
-          echo "::set-output name=bucket-path::${{ github.head_ref }}"
-        fi
+      run: yarn build
+      env:
+        PUBLIC_URL: /${{ inputs.gcpBucketPath }}
+        CHAIN_ID: ${{ env.NETWORK_ID }}
+        ETH_HOSTNAME_HTTP: ${{ inputs.ethUrlHttp }}
+        ETH_HOSTNAME_WS: ${{ inputs.ethUrlWS }}
 
     - name: Deploy to GCP
       uses: thesis/gcp-storage-bucket-action@v3.1.0
@@ -139,7 +138,7 @@ runs:
         service-key: ${{ inputs.gcpServiceKey }}
         project: ${{ env.GOOGLE_PROJECT_ID }}
         bucket-name: ${{ inputs.gcpBucketName }}
-        bucket-path: ${{ steps.set-bucket-path.outputs.bucket-path }}
+        bucket-path: ${{ inputs.gcpBucketPath }}
         build-folder: build
         set-website: ${{ inputs.preview == 'false' }}
         home-page-path: index.html

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -109,6 +109,7 @@ jobs:
           dependentPackagesTag: goerli
           gcpServiceKey: ${{ secrets.KEEP_TEST_CI_UPLOAD_DAPP_JSON_KEY_BASE64 }}
           gcpBucketName: preview.dashboard.test.threshold.network
+          gcpBucketPath: ${{ github.head_ref }}
           preview: true
 
   # This job will be triggered via the `workflow_dispatch` event, as part of the


### PR DESCRIPTION
In the workflow we're executing the `thesis/gcp-storage-bucket-action@v3.1.0`
action. One of its inputs is `bucket-path`, which is an optional
input and is used to configure bucket path.

If in the workflow step executing the action we don't use the
`bucket-path` property, the action will set its `bucket-path` input to
the default value which is `.`. This is the value that we want to use
when workflow is triggered manually or by merge to main.
Previously we thought that setting the action to use
`bucket-name: ${{ github.head_ref }}` property would do the trick of
using `.` for `workflow_dispatch` and `push` events and using
`head_ref` for `pull_request` events (because we thougt the default
value will be used when `bucket-name: ` (without a value) is used in
the action. But this turned out to not be truth. When we use
`bucket-name: ` the behavior is different than when we don't provide the
`bucket-name` property at all. In the first case we don't see the
`bucket-name` property in the runner's log, in the second case we see
the property populated with the default `.` value.
Not having `bucket-name` property in the runner results in wrong
behavior of the action (order of the inputs gets messed up and the
address of bucket gets resolved to gs://<BUCKETNAME>/<BUILDFOLDER>".

As a solution we add a `set-bucket-path` step which creates an output
which value is either `.` or `github.head_ref`, depending if the
latter is configured. We then use this output as value of `bucket-path`
parameter of action `thesis/gcp-storage-bucket-action@v3.1.0`.

Read more about how runner handles empty values here:
https://github.com/actions/runner/issues/924.