### PR TITLE
Update preparation of the artifacts for `solidity-contracts` in `start_dashboard.sh` script 

### DIFF
--- a/scripts/start_dashboard.sh
+++ b/scripts/start_dashboard.sh
@@ -114,7 +114,7 @@ yarn link @keep-network/keep-core
 ./scripts/prepare-dependencies.sh
 printf "${LOG_START}Deploying contracts for threshold solidity contracts...${LOG_START}"
 yarn deploy --network development --reset
-./scripts/prepare-artifacts.sh --network development
+yarn hardhat prepare-artifacts --network development
 yarn link
 
 cd $COMPONENTS_LIB_PATH


### PR DESCRIPTION
In this PR - https://github.com/threshold-network/solidity-contracts/pull/113 - there was a change that changed the way of how we prepare the artifacts in `solidity-contracts` repo. Instead of calling `prepare-artifacts.sh` file we use hardhat helper task (please see this commit - https://github.com/threshold-network/solidity-contracts/pull/113/commits/0c843c620fa0d7e54474736933ad56d5aa3ba3ea).

This PR updates the `start_dashboard` script in `token-dashboard` to do the same, since `prepare-artifacts.sh` file was removed.