### PR TITLE
Update dashboard CI

### DIFF
--- a/.github/actions/build-and-deploy-to-bucket/action.yml
+++ b/.github/actions/build-and-deploy-to-bucket/action.yml
@@ -74,24 +74,29 @@ runs:
         upstream-builds: ${{ inputs.upstreamBuilds }}
         query: |
           threshold-contracts-version = github.com/threshold-network/solidity-contracts#version
-
+          random-beacon-contracts-version = github.com/keep-network/keep-core/random-beacon#version
+          ecdsa-contracts-version = github.com/keep-network/keep-core/ecdsa#version
+          tbtc-v2-contracts-version = github.com/keep-network/tbtc-v2#version
     - name: Set packages versions
       shell: bash
       id: set-packages-versions
       run: |
         if [ ${{ inputs.useUpstreamBuilds }} = 'false' ]; then
           echo "::set-output name=threshold-contracts-version::${{ inputs.dependentPackagesTag }}"
+          echo "::set-output name=random-beacon-contracts-version::${{ inputs.dependentPackagesTag }}"
+          echo "::set-output name=ecdsa-contracts-version::${{ inputs.dependentPackagesTag }}"
+          echo "::set-output name=tbtc-v2-contracts-version::${{ inputs.dependentPackagesTag }}"
         else
           echo "::set-output name=threshold-contracts-version::${{ steps.upstream-builds-query.outputs.threshold-contracts-version }}"
+          echo "::set-output name=random-beacon-contracts-version::${{ steps.upstream-builds-query.outputs.random-beacon-contracts-version }}"
+          echo "::set-output name=ecdsa-contracts-version::${{ steps.upstream-builds-query.outputs.ecdsa-contracts-version }}"
+          echo "::set-output name=tbtc-v2-contracts-version::${{ steps.upstream-builds-query.outputs.tbtc-v2-contracts-version }}"
         fi
 
     # Currently we only support `environment` = `goerli`. We provide explicit
     # version of the `keep-core` package, because using `goerli` tag results in
     # `expected manifest` error - probably caused by bug in Yarn:
     # https://github.com/yarnpkg/yarn/issues/4731.
-
-    # TODO: Add upgrade of @keep-network/random-beacon, @keep-network/ecdsa,
-    # @keep-network/tbtc-v2 once they'll be added as dashboard's dependencies.
     - name: Resolve contracts
       shell: bash
       run: |
@@ -100,7 +105,10 @@ runs:
           @keep-network/keep-core@1.8.1-goerli.0 \
           @keep-network/keep-ecdsa@${{ inputs.environment }} \
           @keep-network/tbtc@${{ inputs.environment }} \
-          @keep-network/coverage-pools@${{ inputs.environment }}
+          @keep-network/coverage-pools@${{ inputs.environment }} \
+          @keep-network/ecdsa@${{ steps.set-packages-versions.outputs.ecdsa-contracts-version }} \
+          @keep-network/random-beacon@${{ steps.set-packages-versions.outputs.random-beacon-contracts-version }} \
+          @keep-network/tbtc-v2@${{ steps.set-packages-versions.outputs.tbtc-v2-contracts-version }}
 
     - name: Run postinstall script
       shell: bash

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -75,7 +75,9 @@ jobs:
             @keep-network/tbtc \
             @keep-network/coverage-pools \
             @keep-network/tbtc-v2 \
-            @keep-network/tbtc-v2.ts
+            @keep-network/tbtc-v2.ts \
+            @keep-network/ecdsa \
+            @keep-network/random-beacon
 
       - name: Run postinstall script
         # `yarn upgrade` doesn't trigger the `postinstall` script.


### PR DESCRIPTION
Depends on: #165
Ref: https://github.com/threshold-network/token-dashboard/pull/165#discussion_r963024513

In #165 we added the `@keep-network/ecdsa` and
`@keep-network/random-beacon` dependencies so we have to update the dashboard
CI as well. Thanks to that the CI will install correct version of contracts
during the build process.