### PR TITLE
Fix staking app slices

### DIFF
--- a/src/store/staking-applications/slice.ts
+++ b/src/store/staking-applications/slice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit"
+import { AnyAction, createSlice, PayloadAction } from "@reduxjs/toolkit"
 import { featureFlags } from "../../constants"
 import {
   StakingProviderAppInfo,
@@ -6,7 +6,7 @@ import {
 } from "../../threshold-ts/applications"
 import { FetchingState } from "../../types"
 import { startAppListening } from "../listener"
-import { setStakes } from "../staking"
+import { providerStaked, setStakes } from "../staking"
 import {
   getSupportedAppsStakingProvidersData,
   getSupportedAppsEffect,
@@ -145,6 +145,27 @@ export const stakingApplicationsSlice = createSlice({
           toAmount
       }
     },
+  },
+  extraReducers: (builder) => {
+    builder.addMatcher(
+      (action: AnyAction) => action.type.match(providerStaked),
+      (state, action: ReturnType<typeof providerStaked>) => {
+        const { stakingProvider } = action.payload
+
+        const defaultAuthData = {
+          authorizedStake: "0",
+          pendingAuthorizationDecrease: "0",
+          remainingAuthorizationDecreaseDelay: "0",
+        }
+
+        state.randomBeacon.stakingProviders.data[stakingProvider] = {
+          ...defaultAuthData,
+        }
+        state.tbtc.stakingProviders.data[stakingProvider] = {
+          ...defaultAuthData,
+        }
+      }
+    )
   },
 })
 

--- a/src/store/staking-applications/slice.ts
+++ b/src/store/staking-applications/slice.ts
@@ -140,10 +140,14 @@ export const stakingApplicationsSlice = createSlice({
       }>
     ) => {
       const { stakingProvider, toAmount, appName } = action.payload
-      if (state[appName].stakingProviders) {
-        state[appName].stakingProviders.data[stakingProvider].authorizedStake =
-          toAmount
-      }
+
+      const stakingProviderData =
+        state[appName]?.stakingProviders.data[stakingProvider]
+
+      if (!stakingProviderData) return
+
+      state[appName].stakingProviders.data[stakingProvider].authorizedStake =
+        toAmount
     },
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
This PR fixes the staking app slices:

- updates the staking app state on `Staked` event- we should set the default values for staking provider for staking apps when the dapp catches the `Staked` event- once the dapp catches the `Staked` event, the `providerStaked` action is dispatched,
- fixes `authorizationIncreased` slice action- we should update the staking provider app data only if the given staking provider exists in a store. Otherwise means that event was not related to the currently logged account.