### PR TITLE
Updates copy from 14 to 45 for cooldown period

### DIFF
--- a/src/components/Modal/DeauthorizeApplicationModal/InititateDeauthorization.tsx
+++ b/src/components/Modal/DeauthorizeApplicationModal/InititateDeauthorization.tsx
@@ -91,20 +91,20 @@ const InitiateDeauthorization: FC<{
           </FlowStep>
           <FlowStep
             preTitle="Step 2"
-            title="14 day cooldown"
+            title="45 day cooldown"
             status={FlowStepStatus.inactive}
             size="sm"
           >
-            You must wait a 14 day cooldown to then confirm the deauthorization.
+            You must wait a 45 day cooldown to then confirm the deauthorization.
             This is 1 transaction.
           </FlowStep>
         </Stack>
         <Alert status="warning">
           <AlertIcon />
-          Take note! In this cooldown period, you cannot increase or decrease
-          your authorization. As a measure of security for the entire network,
-          in the event of slashing you will be slashed based on your initial
-          amount.
+          Take note! In this 45 day cooldown period, you cannot increase or
+          decrease your authorization. As a measure of security for the entire
+          network, in the event of slashing you will be slashed based on your
+          initial amount.
         </Alert>
       </ModalBody>
       <ModalFooter>

--- a/src/components/Modal/StakingApplications/DeauthorizationInitiated.tsx
+++ b/src/components/Modal/StakingApplications/DeauthorizationInitiated.tsx
@@ -45,7 +45,7 @@ const DeauthorizationInitiatedBase: FC<DeauthorizationInitiatedProps> = ({
       <ModalBody>
         <Alert status="success" mb={4}>
           <AlertIcon />
-          Your deauthorization was initiated. Your 14 day cooldown period has
+          Your deauthorization was initiated. Your 45 day cooldown period has
           started.
         </Alert>
         <List spacing="2.5" my="6">
@@ -76,11 +76,11 @@ const DeauthorizationInitiatedBase: FC<DeauthorizationInitiatedProps> = ({
           </FlowStep>
           <FlowStep
             preTitle="Step 2"
-            title="14 day cooldown"
+            title="45 day cooldown"
             status={FlowStepStatus.active}
             size="sm"
           >
-            You must wait a 14 day cooldown to then confirm the deauthorization.
+            You must wait a 45 day cooldown to then confirm the deauthorization.
             This is 1 transaction.
           </FlowStep>
         </Stack>

--- a/src/pages/Staking/HowItWorks/StakingApplications/index.tsx
+++ b/src/pages/Staking/HowItWorks/StakingApplications/index.tsx
@@ -110,7 +110,7 @@ const StakingApplications: PageComponent = () => {
                   <Stack>
                     <BodyMd>Change your authorized amount at any time. </BodyMd>
                     <BodyXs>
-                      There is a deauthorization cooldown period of 14 days.
+                      There is a deauthorization cooldown period of 45 days.
                     </BodyXs>
                   </Stack>
                 </BodyMd>

--- a/src/pages/Staking/HowItWorks/StakingOverview/AuthorizingApplicationsCard.tsx
+++ b/src/pages/Staking/HowItWorks/StakingOverview/AuthorizingApplicationsCard.tsx
@@ -60,10 +60,10 @@ export const AuthorizingApplicationsCard: FC<ComponentProps<typeof Card>> = (
         <FlowStep
           status={FlowStepStatus.active}
           preTitle="Step 2"
-          title="14 day cooldown"
+          title="45 day cooldown"
           size="sm"
         >
-          You must wait a 14 day cooldown to then confirm the deauthorization.
+          You must wait a 45 day cooldown to then confirm the deauthorization.
           This is 1 transaction.
         </FlowStep>
       </Stack>


### PR DESCRIPTION
The application authorization cooldown period is finalized at 45 days for the mulit app staking so the copy needs to be updated on the dashboard.

