### PR TITLE
Fix condition for executing step getting upstream builds

### DIFF
--- a/.github/workflows/reusable-build-and-publish.yml
+++ b/.github/workflows/reusable-build-and-publish.yml
@@ -88,7 +88,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Get upstream packages versions
-        if: inputs.upstreamBuilds == true
+        if: inputs.useUpstreamBuilds == true
         uses: keep-network/ci/actions/upstream-builds-query@v2
         id: upstream-builds-query
         with:


### PR DESCRIPTION
We were using wrong input to determine if the `Get upstream packages versions` step should be run. The `upstreamBuilds` is not boolean, we should have been using `useUpstreamBuilds` instead.

Previous implementation was resulting in incorrect resolving of the versions, see command in `Resolve contracts` step in https://github.com/threshold-network/token-dashboard/actions/runs/3157088578/jobs/5137628670.