### PR TITLE
Update auth/dauth form validation

### DIFF
--- a/src/components/Forms/TokenAmountForm.tsx
+++ b/src/components/Forms/TokenAmountForm.tsx
@@ -16,25 +16,22 @@ export type FormValues = {
   tokenAmount: string
 }
 
-type TokenAmountFormProps = {
-  onSubmitForm: (tokenAmount: string) => void
+export type TokenAmountFormBaseProps = {
   submitButtonText: string
   maxTokenAmount: string | number
-  initialTokenAmount?: string
-  label?: string
+  label?: string | JSX.Element
   helperText?: string
   icon?: typeof Icon
   isDisabled?: boolean
   shouldValidateForm?: boolean
   shouldDisplayMaxAmountInLabel?: boolean
   token?: { decimals: number; symbol: string }
-  innerRef?: Ref<FormikProps<FormValues>>
   placeholder?: string
   minTokenAmount?: string | number
 }
 
-const TokenAmountFormBase: FC<
-  TokenAmountFormProps & FormikProps<FormValues>
+export const TokenAmountFormBase: FC<
+  TokenAmountFormBaseProps & FormikProps<FormValues>
 > = ({
   submitButtonText,
   maxTokenAmount,
@@ -83,6 +80,12 @@ const TokenAmountFormBase: FC<
     </Form>
   )
 }
+
+export type TokenAmountFormProps = {
+  innerRef?: Ref<FormikProps<FormValues>>
+  onSubmitForm: (tokenAmount: string) => void
+  initialTokenAmount?: string
+} & TokenAmountFormBaseProps
 
 export const TokenAmountForm = withFormik<TokenAmountFormProps, FormValues>({
   mapPropsToValues: (props) => ({

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -1,0 +1,163 @@
+import { FC, Ref, useEffect, useState } from "react"
+import { BigNumber } from "ethers"
+import { FormikErrors, FormikProps, withFormik } from "formik"
+import { BodyMd, BodySm } from "@threshold-network/components"
+import {
+  TokenAmountFormBase,
+  TokenAmountFormBaseProps,
+  FormValues,
+} from "../Forms"
+import {
+  DEFAULT_MIN_VALUE,
+  getErrorsObj,
+  validateAmountInRange,
+} from "../../utils/forms"
+import { formatTokenAmount } from "../../utils/formatAmount"
+
+type ComponentProps = {
+  totalStake: string
+  authorizedAmount: string
+  isAuthorization?: boolean
+} & Omit<TokenAmountFormBaseProps, "label" | "maxTokenAmount">
+
+const Label: FC<{ label: string; remainigAmount: string }> = ({
+  label,
+  remainigAmount,
+}) => {
+  return (
+    <>
+      <BodyMd as="span" fontWeight="bold">
+        {label}
+      </BodyMd>
+      <BodySm as="span" color="gray.500" float="right">
+        Remaining Balance: {formatTokenAmount(remainigAmount)} T
+      </BodySm>
+    </>
+  )
+}
+
+const StakingApplicationFormBase: FC<
+  ComponentProps & FormikProps<FormValues>
+> = ({
+  totalStake,
+  submitButtonText,
+  isDisabled,
+  helperText,
+  authorizedAmount,
+  isAuthorization = true,
+  ...formikProps
+}) => {
+  const { values } = formikProps
+  const { tokenAmount } = values
+  const [remainigAmount, setRemainingAmount] = useState("0")
+  const [maxAmount, setMaxAmount] = useState("0")
+
+  useEffect(() => {
+    if (!isAuthorization) {
+      setMaxAmount(authorizedAmount)
+    } else {
+      setMaxAmount(BigNumber.from(totalStake).sub(authorizedAmount).toString())
+    }
+  }, [authorizedAmount, totalStake, isAuthorization])
+
+  useEffect(() => {
+    const _tokenAmount = BigNumber.from(tokenAmount || "0")
+    const _max = BigNumber.from(maxAmount)
+    setRemainingAmount(
+      tokenAmount
+        ? _tokenAmount.gte(_max)
+          ? "0"
+          : _max.sub(_tokenAmount).toString()
+        : maxAmount
+    )
+  }, [tokenAmount, authorizedAmount, totalStake, maxAmount])
+
+  return (
+    <TokenAmountFormBase
+      label={
+        <Label
+          label={isAuthorization ? "Increase Amount" : "Decrease Amount"}
+          remainigAmount={remainigAmount}
+        />
+      }
+      submitButtonText={submitButtonText}
+      isDisabled={isDisabled}
+      maxTokenAmount={totalStake}
+      placeholder={"Enter amount"}
+      helperText={helperText}
+      {...formikProps}
+    />
+  )
+}
+
+type StakingAppFormBaseProps = {
+  initialAmount?: string
+  minimumAuthorizationAmount: string
+  innerRef?: Ref<FormikProps<FormValues>>
+  onSubmitForm: (tokenAmount: string) => void
+} & ComponentProps
+
+const authorizationValidation = (
+  values: FormValues,
+  props: StakingAppFormBaseProps
+) => {
+  const errors: FormikErrors<FormValues> = {}
+
+  const { tokenAmount } = values
+  const { authorizedAmount, totalStake, minimumAuthorizationAmount } = props
+
+  const _authorizedAmount = BigNumber.from(authorizedAmount)
+  const _max = BigNumber.from(totalStake).sub(_authorizedAmount)
+  const _minimumAuthorizationAmount = BigNumber.from(minimumAuthorizationAmount)
+
+  const min = _authorizedAmount.gt(_minimumAuthorizationAmount)
+    ? DEFAULT_MIN_VALUE
+    : _minimumAuthorizationAmount.sub(_authorizedAmount)
+
+  errors.tokenAmount = validateAmountInRange(
+    tokenAmount,
+    _max.toString(),
+    min.toString()
+  )
+
+  return getErrorsObj(errors)
+}
+
+const deauthorizationValidation = (
+  values: FormValues,
+  props: StakingAppFormBaseProps
+) => {
+  const errors: FormikErrors<FormValues> = {}
+
+  const { tokenAmount } = values
+  const { authorizedAmount, minimumAuthorizationAmount } = props
+  const max = BigNumber.from(authorizedAmount).sub(minimumAuthorizationAmount)
+  const _tokenAmount = BigNumber.from(tokenAmount)
+
+  if (_tokenAmount.lt(authorizedAmount)) {
+    errors.tokenAmount = validateAmountInRange(
+      tokenAmount,
+      max.toString(),
+      DEFAULT_MIN_VALUE
+    )
+  }
+
+  return getErrorsObj(errors)
+}
+
+export const StakingAppForm = withFormik<StakingAppFormBaseProps, FormValues>({
+  mapPropsToValues: ({ initialAmount }) => ({
+    tokenAmount: initialAmount || "0",
+  }),
+  validate: (values, props) => {
+    const validationFn = props.isAuthorization
+      ? authorizationValidation
+      : deauthorizationValidation
+
+    return validationFn(values, props)
+  },
+  handleSubmit: (values, { props }) => {
+    props.onSubmitForm(values.tokenAmount)
+  },
+  displayName: "StakingAppForm",
+})(StakingApplicationFormBase)

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -70,7 +70,7 @@ const StakingApplicationFormBase: FC<
           : _max.sub(_tokenAmount).toString()
         : maxAmount
     )
-  }, [tokenAmount, authorizedAmount, totalStake, maxAmount])
+  }, [tokenAmount, maxAmount])
 
   return (
     <TokenAmountFormBase

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -82,7 +82,7 @@ const StakingApplicationFormBase: FC<
       }
       submitButtonText={submitButtonText}
       isDisabled={isDisabled}
-      maxTokenAmount={totalStake}
+      maxTokenAmount={maxAmount}
       placeholder={"Enter amount"}
       helperText={helperText}
       {...formikProps}

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -20,9 +20,9 @@ type ComponentProps = {
   isAuthorization?: boolean
 } & Omit<TokenAmountFormBaseProps, "label" | "maxTokenAmount">
 
-const Label: FC<{ label: string; remainigAmount: string }> = ({
+const Label: FC<{ label: string; remainingAmount: string }> = ({
   label,
-  remainigAmount,
+  remainingAmount,
 }) => {
   return (
     <>
@@ -30,7 +30,7 @@ const Label: FC<{ label: string; remainigAmount: string }> = ({
         {label}
       </BodyMd>
       <BodySm as="span" color="gray.500" float="right">
-        Remaining Balance: {formatTokenAmount(remainigAmount)} T
+        Remaining Balance: {formatTokenAmount(remainingAmount)} T
       </BodySm>
     </>
   )
@@ -49,7 +49,7 @@ const StakingApplicationFormBase: FC<
 }) => {
   const { values } = formikProps
   const { tokenAmount } = values
-  const [remainigAmount, setRemainingAmount] = useState("0")
+  const [remainingAmount, setRemainingAmount] = useState("0")
   const [maxAmount, setMaxAmount] = useState("0")
 
   useEffect(() => {
@@ -77,7 +77,7 @@ const StakingApplicationFormBase: FC<
       label={
         <Label
           label={isAuthorization ? "Increase Amount" : "Decrease Amount"}
-          remainigAmount={remainigAmount}
+          remainingAmount={remainingAmount}
         />
       }
       submitButtonText={submitButtonText}

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -134,7 +134,7 @@ const deauthorizationValidation = (
   const max = BigNumber.from(authorizedAmount).sub(minimumAuthorizationAmount)
   const _tokenAmount = BigNumber.from(tokenAmount)
 
-  if (_tokenAmount.lt(authorizedAmount)) {
+  if (!_tokenAmount.eq(authorizedAmount)) {
     errors.tokenAmount = validateAmountInRange(
       tokenAmount,
       max.toString(),

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -146,7 +146,7 @@ const deauthorizationValidation = (
       {
         ...defaultValidationOptions,
         lessThanValidationMsg(amount) {
-          return `${defaultLessThanMsg(amount)} or ${formatTokenAmount(
+          return `${defaultLessThanMsg(amount)} or equal to ${formatTokenAmount(
             authorizedAmount.toString()
           )} T`
         },

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -8,6 +8,8 @@ import {
   FormValues,
 } from "../Forms"
 import {
+  defaultLessThanMsg,
+  defaultValidationOptions,
   DEFAULT_MIN_VALUE,
   getErrorsObj,
   validateAmountInRange,
@@ -138,7 +140,15 @@ const deauthorizationValidation = (
     errors.tokenAmount = validateAmountInRange(
       tokenAmount,
       max.toString(),
-      DEFAULT_MIN_VALUE
+      DEFAULT_MIN_VALUE,
+      {
+        ...defaultValidationOptions,
+        lessThanValidationMsg(amount) {
+          return `${defaultLessThanMsg(amount)} or ${formatTokenAmount(
+            authorizedAmount.toString()
+          )} T`
+        },
+      }
     )
   }
 

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -108,17 +108,19 @@ const authorizationValidation = (
   const { tokenAmount } = values
   const { authorizedAmount, totalStake, minimumAuthorizationAmount } = props
 
-  const _authorizedAmount = BigNumber.from(authorizedAmount)
-  const _max = BigNumber.from(totalStake).sub(_authorizedAmount)
-  const _minimumAuthorizationAmount = BigNumber.from(minimumAuthorizationAmount)
+  const authorizedAmountInBN = BigNumber.from(authorizedAmount)
+  const max = BigNumber.from(totalStake).sub(authorizedAmountInBN)
+  const minimumAuthorizationAmountInBN = BigNumber.from(
+    minimumAuthorizationAmount
+  )
 
-  const min = _authorizedAmount.gt(_minimumAuthorizationAmount)
+  const min = authorizedAmountInBN.gt(minimumAuthorizationAmountInBN)
     ? DEFAULT_MIN_VALUE
-    : _minimumAuthorizationAmount.sub(_authorizedAmount)
+    : minimumAuthorizationAmountInBN.sub(authorizedAmountInBN)
 
   errors.tokenAmount = validateAmountInRange(
     tokenAmount,
-    _max.toString(),
+    max.toString(),
     min.toString()
   )
 
@@ -134,9 +136,9 @@ const deauthorizationValidation = (
   const { tokenAmount } = values
   const { authorizedAmount, minimumAuthorizationAmount } = props
   const max = BigNumber.from(authorizedAmount).sub(minimumAuthorizationAmount)
-  const _tokenAmount = BigNumber.from(tokenAmount || "0")
+  const tokenAmountInBN = BigNumber.from(tokenAmount || "0")
 
-  if (!_tokenAmount.eq(authorizedAmount)) {
+  if (!tokenAmountInBN.eq(authorizedAmount)) {
     errors.tokenAmount = validateAmountInRange(
       tokenAmount,
       max.toString(),

--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -132,7 +132,7 @@ const deauthorizationValidation = (
   const { tokenAmount } = values
   const { authorizedAmount, minimumAuthorizationAmount } = props
   const max = BigNumber.from(authorizedAmount).sub(minimumAuthorizationAmount)
-  const _tokenAmount = BigNumber.from(tokenAmount)
+  const _tokenAmount = BigNumber.from(tokenAmount || "0")
 
   if (!_tokenAmount.eq(authorizedAmount)) {
     errors.tokenAmount = validateAmountInRange(

--- a/src/pages/Staking/AuthorizeStakingApps/AuthorizeApplicationsCardCheckbox/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/AuthorizeApplicationsCardCheckbox/index.tsx
@@ -17,11 +17,10 @@ import {
   HStack,
 } from "@threshold-network/components"
 import { InfoIcon } from "@chakra-ui/icons"
-import { FC, RefObject, useCallback, useEffect } from "react"
-import { FormValues, TokenAmountForm } from "../../../../components/Forms"
+import { FC, Ref, useCallback, useEffect } from "react"
+import { FormValues } from "../../../../components/Forms"
 import { AppAuthorizationInfo } from "./AppAuthorizationInfo"
 import { formatTokenAmount } from "../../../../utils/formatAmount"
-import { WeiPerEther } from "@ethersproject/constants"
 import { useModal } from "../../../../hooks/useModal"
 import { ModalType } from "../../../../enums"
 import { StakingAppName } from "../../../../store/staking-applications"
@@ -33,6 +32,7 @@ import {
 import InfoBox from "../../../../components/InfoBox"
 import { formatDate } from "../../../../utils/date"
 import { calculatePercenteage } from "../../../../utils/percentage"
+import { StakingAppForm } from "../../../../components/StakingApplicationForms"
 
 interface CommonProps {
   stakingAppId: StakingAppName | "pre"
@@ -87,7 +87,7 @@ export interface AuthorizeApplicationsCardCheckboxProps extends BoxProps {
   maxAuthAmount: string
   minAuthAmount: string
   canSubmitForm?: boolean
-  formRef?: RefObject<FormikProps<FormValues>>
+  formRef?: Ref<FormikProps<FormValues>>
 }
 
 const gridTemplate = {
@@ -299,10 +299,9 @@ export const AuthorizeApplicationsCardCheckbox: FC<
         </FilterTabs>
         {!hasPendingDeauthorization && (
           <GridItem gridArea="token-amount-form" mt={5}>
-            <TokenAmountForm
+            <StakingAppForm
               innerRef={formRef}
               onSubmitForm={onSubmitForm}
-              label="Amount"
               submitButtonText={
                 isIncreaseAction
                   ? appAuthData.isAuthorized
@@ -311,20 +310,18 @@ export const AuthorizeApplicationsCardCheckbox: FC<
                   : "Initiate Deauthorization"
               }
               isDisabled={!canSubmitForm}
-              maxTokenAmount={
-                isIncreaseAction ? maxAuthAmount : authorizedStake ?? "0"
-              }
+              totalStake={totalInTStake}
               placeholder={"Enter amount"}
-              minTokenAmount={
-                isIncreaseAction
-                  ? appAuthData.percentage === 0
-                    ? minAuthAmount
-                    : WeiPerEther.toString()
-                  : "0"
+              minimumAuthorizationAmount={minAuthAmount}
+              authorizedAmount={appAuthData.authorizedStake}
+              helperText={
+                appAuthData.isAuthorized && isIncreaseAction
+                  ? undefined
+                  : `Minimum ${formatTokenAmount(minAuthAmount)} T for ${
+                      appAuthData.label
+                    }`
               }
-              helperText={`Minimum ${formatTokenAmount(minAuthAmount)} T for ${
-                appAuthData.label
-              }`}
+              isAuthorization={isIncreaseAction}
             />
           </GridItem>
         )}

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -15,18 +15,22 @@ type ValidationOptions = {
 }
 export const DEFAULT_MIN_VALUE = WeiPerEther.toString()
 
-const defaultLessThanMsg: ValidationMsg = (minAmount) => {
+export const defaultLessThanMsg: (minAmount: string) => string = (
+  minAmount
+) => {
   return `The value should be less than or equal ${formatTokenAmount(
     minAmount
   )}`
 }
 
-const defaultGreaterThanMsg: ValidationMsg = (maxAmount) => {
+export const defaultGreaterThanMsg: (minAmount: string) => string = (
+  maxAmount
+) => {
   return `The value should be greater than or equal ${formatTokenAmount(
     maxAmount
   )}`
 }
-const defaultValidationOptions: ValidationOptions = {
+export const defaultValidationOptions: ValidationOptions = {
   greaterThanValidationMsg: defaultGreaterThanMsg,
   lessThanValidationMsg: defaultLessThanMsg,
   requiredMsg: "Required",


### PR DESCRIPTION
We need to update the validation for authorize/deauthorize form to match the validation on the smart contract side. There are 3 scenarios:

1. Application is unauthorized- first-time authorization:
- the authorization amount should be greater than the minimum authorization amount for a given application and less than/equal to the total staked balance of the stake.

2. Increase authorization- an application is already authorized:
- the increase amount should be greater than 0 and less than/equal to the remaining stake amount: Eg:
  - total staked balance in T: 100 000 T,
  - first authorization amount: 40 000 T,
  - max increase amount is 60 000 T.

3. Deatuhorization:
- the decrease amount should be greater than 0 and the authorization amount after deauthorization should be greater than/equal to the minimum authorization amount eg:
  - minimum authorization amount: 40 000 T,
  - authorization amount: 100 000 T,
  - the authorizer can deauthorize the staking application by up to 60 000 T. An authorizer can also fully deauthorize, so the value can be 100 000T.

Ref:
https://github.com/keep-network/keep-core/blob/4df5ceb01fd1bd2d55a39eb65db6c14d5a275d18/solidity/random-beacon/contracts/libraries/BeaconAuthorization.sol#L278-L281
https://github.com/keep-network/keep-core/blob/main/solidity/ecdsa/contracts/libraries/EcdsaAuthorization.sol#L281-L284
https://github.com/threshold-network/solidity-contracts/blob/main/contracts/staking/TokenStaking.sol#L1305-L1313