### PR TITLE
Fixes authorizer input bug  that caused an app crash

### DIFF
--- a/src/components/Modal/ConfirmStakingParams/AdvancedParamsForm.tsx
+++ b/src/components/Modal/ConfirmStakingParams/AdvancedParamsForm.tsx
@@ -1,4 +1,4 @@
-import { FC, Ref, useMemo } from "react"
+import { FC, Ref } from "react"
 import { FormikProps, FormikErrors, withFormik } from "formik"
 import { Form, FormikInput } from "../../Forms"
 import { getErrorsObj, validateETHAddress } from "../../../utils/forms"

--- a/src/components/Modal/ConfirmStakingParams/AdvancedParamsForm.tsx
+++ b/src/components/Modal/ConfirmStakingParams/AdvancedParamsForm.tsx
@@ -1,11 +1,11 @@
-import { FC, Ref } from "react"
+import { FC, Ref, useMemo } from "react"
 import { FormikProps, FormikErrors, withFormik } from "formik"
 import { Form, FormikInput } from "../../Forms"
 import { getErrorsObj, validateETHAddress } from "../../../utils/forms"
 import { Alert, AlertIcon } from "@chakra-ui/react"
 import { useWeb3React } from "@web3-react/core"
 import { BodyXs } from "@threshold-network/components"
-import { isSameETHAddress } from "../../../web3/utils"
+import { isAddress, isSameETHAddress } from "../../../web3/utils"
 
 export interface FormValues {
   stakingProvider: string
@@ -43,15 +43,16 @@ const AdvancedParamsFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
         label="Authorizer Address"
         helperText="This address will authorize applications."
       />
-      {!isSameETHAddress(authorizer, account as string) && (
-        <Alert status="warning" mt={6}>
-          <AlertIcon />
-          <BodyXs>
-            Authorizer address is different than your wallet address. We
-            recommend you to use the same address as your wallet address.
-          </BodyXs>
-        </Alert>
-      )}
+      {isAddress(authorizer) &&
+        !isSameETHAddress(authorizer, account as string) && (
+          <Alert status="warning" mt={6}>
+            <AlertIcon />
+            <BodyXs>
+              Authorizer address is different than your wallet address. We
+              recommend you to use the same address as your wallet address.
+            </BodyXs>
+          </Alert>
+        )}
     </Form>
   )
 }

--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -1,16 +1,14 @@
 import {
-  Alert,
   AlertBox,
   AlertDescription,
-  AlertIcon,
   Badge,
   BodyLg,
-  BodySm,
   Button,
   Card,
   H5,
   HStack,
   LineDivider,
+  useColorModeValue,
 } from "@threshold-network/components"
 import { BigNumber } from "ethers"
 import { useSelector } from "react-redux"
@@ -23,7 +21,6 @@ import AuthorizeApplicationsCardCheckbox, {
   AppAuthDataProps,
 } from "./AuthorizeApplicationsCardCheckbox"
 import { FC, useEffect, useRef, useState, RefObject } from "react"
-import { featureFlags } from "../../../constants"
 import {
   requestStakeByStakingProvider,
   selectStakeByStakingProvider,
@@ -41,7 +38,6 @@ import { FormValues } from "../../../components/Forms"
 import { useAppDispatch } from "../../../hooks/store"
 import { stakingApplicationsSlice } from "../../../store/staking-applications"
 import BundledRewardsAlert from "../../../components/BundledRewardsAlert"
-import { useColorModeValue } from "@chakra-ui/react"
 
 const AuthorizeStakingAppsPage: FC = () => {
   const { stakingProviderAddress } = useParams()
@@ -201,7 +197,7 @@ const AuthorizeStakingAppsPage: FC = () => {
     )
   }
 
-  const alertTextColor = useColorModeValue("gray.700", "white")
+  const alertTextColor = useColorModeValue("gray.900", "white")
 
   return active ? (
     <>
@@ -294,13 +290,5 @@ const AuthorizeStakingAppsPage: FC = () => {
     <H5>{`Please connect your wallet.`}</H5>
   )
 }
-
-// AuthorizeStakingAppsPage.route = {
-//   path: "authorize/:stakingProviderAddress",
-//   index: false,
-//   title: "Authorize",
-//   hideFromMenu: true,
-//   isPageEnabled: featureFlags.MULTI_APP_STAKING,
-// }
 
 export default AuthorizeStakingAppsPage

--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -41,6 +41,7 @@ import { FormValues } from "../../../components/Forms"
 import { useAppDispatch } from "../../../hooks/store"
 import { stakingApplicationsSlice } from "../../../store/staking-applications"
 import BundledRewardsAlert from "../../../components/BundledRewardsAlert"
+import { useColorModeValue } from "@chakra-ui/react"
 
 const AuthorizeStakingAppsPage: FC = () => {
   const { stakingProviderAddress } = useParams()
@@ -200,6 +201,8 @@ const AuthorizeStakingAppsPage: FC = () => {
     )
   }
 
+  const alertTextColor = useColorModeValue("gray.700", "white")
+
   return active ? (
     <>
       <Card>
@@ -227,7 +230,7 @@ const AuthorizeStakingAppsPage: FC = () => {
           </AlertBox>
         )}
         <AlertBox status="magic" alignItems="flex-start">
-          <AlertDescription color={"gray.700"}>
+          <AlertDescription color={alertTextColor}>
             In order to earn rewards, please authorize Threshold apps to use
             your stake. Note that you can authorize 100% of your stake for all
             of the apps. You can change this amount at any time.

--- a/src/web3/utils/address.ts
+++ b/src/web3/utils/address.ts
@@ -20,6 +20,7 @@ export const isSameETHAddress = (
   address1: string,
   address2: string
 ): boolean => {
+  // TODO: this has the potential to cause an app crash if the addresses passed are not valid ETH addresses
   return getAddress(address1) === getAddress(address2)
 }
 


### PR DESCRIPTION
The authorizer input would crash the app if the user changed the value because of the `isSameETHAddress` validation that we used.

I think we should think about impacts of adding this address validation to the `isSameETHAddress` method to avoid future bugs, but for now this will patch the issue and prepare us for the multi app staking launch