### PR TITLE
Fix links in staking how it work page

### DIFF
--- a/src/enums/externalHref.ts
+++ b/src/enums/externalHref.ts
@@ -20,4 +20,6 @@ export enum ExternalHref {
   p2pValidator = "https://p2p.org/",
   infStones = "https://infstones.com/",
   setupNodes = "https://docs.threshold.network/",
+  tbtcNodeDocs = "https://docs.threshold.network/guides/threshold-applications/tbtc-v2-client-setup",
+  randomBeaconNodeDocs = "https://docs.threshold.network/guides/threshold-applications/tbtc-v2-client-setup",
 }

--- a/src/pages/Staking/HowItWorks/StakingApplications/index.tsx
+++ b/src/pages/Staking/HowItWorks/StakingApplications/index.tsx
@@ -107,14 +107,12 @@ const StakingApplications: PageComponent = () => {
             <ListItem>
               <HStack spacing={4}>
                 <Image h="32px" w="32px" src={iconMap.arrows[colorMode]} />
-                <BodyMd>
-                  <Stack>
-                    <BodyMd>Change your authorized amount at any time. </BodyMd>
-                    <BodyXs>
-                      There is a deauthorization cooldown period of 45 days.
-                    </BodyXs>
-                  </Stack>
-                </BodyMd>
+                <Stack>
+                  <BodyMd>Change your authorized amount at any time. </BodyMd>
+                  <BodyXs>
+                    There is a deauthorization cooldown period of 45 days.
+                  </BodyXs>
+                </Stack>
               </HStack>
             </ListItem>
           </List>

--- a/src/pages/Staking/HowItWorks/StakingApplications/index.tsx
+++ b/src/pages/Staking/HowItWorks/StakingApplications/index.tsx
@@ -29,6 +29,7 @@ import { PageComponent } from "../../../../types"
 import { ExternalHref } from "../../../../enums"
 import { featureFlags } from "../../../../constants"
 import ExternalLink from "../../../../components/ExternalLink"
+import { Link as RouterLink } from "react-router-dom"
 import { ColorMode, List, ListItem, useColorMode } from "@chakra-ui/react"
 
 const preNodeSteps = ["Run a PRE node", "Have a staked balance"]
@@ -129,16 +130,17 @@ const StakingApplications: PageComponent = () => {
           ctaButtons={
             <VStack mb={6}>
               <Button
-                as={ExternalLink}
+                as={RouterLink}
                 textDecoration="none"
-                href="/somewhere"
+                to="/staking"
                 width="full"
-                text="Authorize TBTC"
-              />
+              >
+                Authorize TBTC
+              </Button>
               <Button
                 as={ExternalLink}
                 textDecoration="none"
-                href="/somewhere"
+                href="/staking"
                 width="full"
                 variant="outline"
                 text="TBTC Node Docs"
@@ -155,17 +157,18 @@ const StakingApplications: PageComponent = () => {
           ctaButtons={
             <VStack mb={6}>
               <Button
-                as={ExternalLink}
+                as={RouterLink}
                 textDecoration="none"
-                href="/somewhere"
+                to="/staking"
                 width="full"
-                text="Authorize Random Beacon"
-              />
+              >
+                Authorize Random Beacon
+              </Button>
 
               <Button
                 as={ExternalLink}
                 textDecoration="none"
-                href="/somewhere"
+                href="/staking"
                 width="full"
                 variant="outline"
                 text="Random Beacon Node Docs"

--- a/src/pages/Staking/HowItWorks/StakingApplications/index.tsx
+++ b/src/pages/Staking/HowItWorks/StakingApplications/index.tsx
@@ -138,7 +138,7 @@ const StakingApplications: PageComponent = () => {
               <Button
                 as={ExternalLink}
                 textDecoration="none"
-                href="/staking"
+                href={ExternalHref.tbtcNodeDocs}
                 width="full"
                 variant="outline"
                 text="TBTC Node Docs"
@@ -166,7 +166,7 @@ const StakingApplications: PageComponent = () => {
               <Button
                 as={ExternalLink}
                 textDecoration="none"
-                href="/staking"
+                href={ExternalHref.randomBeaconNodeDocs}
                 width="full"
                 variant="outline"
                 text="Random Beacon Node Docs"


### PR DESCRIPTION
Fixes the links for how it works page of the staking page. The fixes was made for four buttons:
- Authorize TBTC
- TBTC Node Docs
- Authorize Random Beacon
- Random Beacon Node Docs

![image](https://user-images.githubusercontent.com/40306834/193559293-f8d642b2-1a30-4b66-8ce8-9a9722d48ba4.png)

Also removes a warning - `<p> cannot appear as a descendant of <p>.`

