### PR TITLE
Fix displaying new apps to authorize modal

### DIFF
--- a/src/store/connected-account/effects.ts
+++ b/src/store/connected-account/effects.ts
@@ -1,5 +1,7 @@
 import { AnyAction } from "@reduxjs/toolkit"
+import { isAddressZero } from "../../web3/utils"
 import { AppListenerEffectAPI } from "../listener"
+import { mapOperatorToStakingProviderModalClosed } from "../modalQueue"
 import { setRolesOf } from "./connectedAccountSlice"
 
 export const getRolesOf = async (
@@ -10,18 +12,24 @@ export const getRolesOf = async (
     const { connectedAccount } = listenerApi.getState()
     const { address } = connectedAccount
 
-    if (address) {
-      listenerApi.unsubscribe()
-      const { owner, authorizer, beneficiary } =
-        await listenerApi.extra.threshold.staking.rolesOf(address)
-      listenerApi.dispatch(
-        setRolesOf({
-          owner,
-          authorizer,
-          beneficiary,
-        })
-      )
+    if (!address) return
+    listenerApi.unsubscribe()
+    const { owner, authorizer, beneficiary } =
+      await listenerApi.extra.threshold.staking.rolesOf(address)
+    if (
+      isAddressZero(owner) &&
+      isAddressZero(authorizer) &&
+      isAddressZero(beneficiary)
+    ) {
+      listenerApi.dispatch(mapOperatorToStakingProviderModalClosed())
     }
+    listenerApi.dispatch(
+      setRolesOf({
+        owner,
+        authorizer,
+        beneficiary,
+      })
+    )
   } catch (error) {
     console.log("Could not fetch roles for connected staking provider: ", error)
     listenerApi.subscribe()


### PR DESCRIPTION
The New Apps To Authorize modal was not displayed for the owner that was not a staking provider. This commit fixes that by dispatching the event that set the mapOperatorToStakingPprovitedModal as closed so the condition that displays the authorize new apps modal is met.