### PR TITLE
Staking app card updates

### DIFF
--- a/src/components/StakingApplicationForms/index.tsx
+++ b/src/components/StakingApplicationForms/index.tsx
@@ -56,9 +56,13 @@ const StakingApplicationFormBase: FC<
 
   useEffect(() => {
     if (!isAuthorization) {
-      setMaxAmount(authorizedAmount)
+      setMaxAmount(authorizedAmount || "0")
     } else {
-      setMaxAmount(BigNumber.from(totalStake).sub(authorizedAmount).toString())
+      setMaxAmount(
+        BigNumber.from(totalStake || "0")
+          .sub(authorizedAmount || "0")
+          .toString()
+      )
     }
   }, [authorizedAmount, totalStake, isAuthorization])
 


### PR DESCRIPTION
This PR fixes the `FilterTab` component in the staking application card. We should reset the form if we switch between tabs. The `Increase` tab should be disabled if there is a pending deauthorization. The `Decrease` tab should be disabled if the authorized stake is `0`-when a user has not yet authorized the staking app.