### PR TITLE
Fix warning caused by AuthorizeApplciationRow

### DIFF
--- a/src/pages/Staking/StakeCard/StakeApplications/AuthorizeApplicationRow.tsx
+++ b/src/pages/Staking/StakeCard/StakeApplications/AuthorizeApplicationRow.tsx
@@ -25,11 +25,16 @@ const AuthorizeApplicationRow: FC<AuthorizeApplicationRowProps> = ({
   const { label, isAuthorized, percentage } = appAuthData
   return (
     <HStack justify="space-between" {...restProps}>
-      <BoxLabel>
-        <HStack>
-          {isAuthorized && <CheckCircleIcon w={4} h={4} color="green.500" />}
-          <BodySm>{label} App</BodySm>
-        </HStack>
+      <BoxLabel
+        size="sm"
+        status="secondary"
+        icon={
+          isAuthorized ? (
+            <CheckCircleIcon w={4} h={4} color="green.500" />
+          ) : null
+        }
+      >
+        {label} App
       </BoxLabel>
       {isAuthorized ? (
         <HStack width="40%">

--- a/src/pages/Staking/StakeCard/StakeApplications/index.tsx
+++ b/src/pages/Staking/StakeCard/StakeApplications/index.tsx
@@ -51,7 +51,7 @@ const StakeApplications: FC<{ stakingProvider: string }> = ({
         !isTbtcFetching &&
         !isRandomBeaconFetching && <BundledRewardsAlert mb="4" />}
       <AuthorizeApplicationRow
-        mb={"3"}
+        my={"3"}
         appAuthData={appsAuthData.tbtc}
         stakingProvider={stakingProvider}
       />


### PR DESCRIPTION
After we made some changes in the AuthorizeApplicationRow (https://github.com/threshold-network/token-dashboard/pull/257) two warnings in the console appeared that we missed during review process:

`<p> cannot appear as a descendant of <p>`

and

`<div> cannot appear as a descendant of <p>`

Turne out we used BoxLabel which is wrapped with TypographyElement. Because of that we shouldn't use `Body` or other typography components as children of BoxLabel.