### PR TITLE
Fix multi-app staking flow

### DIFF
--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -83,10 +83,6 @@ const AuthorizeStakingAppsPage: FC = () => {
     dispatch(stakingApplicationsSlice.actions.getSupportedApps({}))
   }, [dispatch, account])
 
-  const tbtcMinAuthAmount = useStakingAppMinAuthorizationAmount("tbtc")
-  const randomBeaconMinAuthAmount =
-    useStakingAppMinAuthorizationAmount("randomBeacon")
-
   const tbtcApp = useStakingAppDataByStakingProvider(
     "tbtc",
     stakingProviderAddress || AddressZero
@@ -95,17 +91,6 @@ const AuthorizeStakingAppsPage: FC = () => {
     "randomBeacon",
     stakingProviderAddress || AddressZero
   )
-
-  const stake = useSelector((state: RootState) =>
-    selectStakeByStakingProvider(state, stakingProviderAddress!)
-  ) as StakeData
-
-  const isLoggedInAsAuthorizer =
-    stake && account ? isSameETHAddress(stake.authorizer, account) : false
-
-  const isInactiveStake = stake
-    ? BigNumber.from(stake?.totalInTStake).isZero()
-    : false
 
   const appsAuthData: {
     [appName: string]: AppAuthDataProps & { address?: string }
@@ -129,6 +114,33 @@ const AuthorizeStakingAppsPage: FC = () => {
       label: "PRE",
     },
   }
+
+  useEffect(() => {
+    if (tbtcApp.isAuthorized) {
+      setSelectedApps((selectedApps) =>
+        selectedApps.filter(({ stakingAppId }) => stakingAppId !== "tbtc")
+      )
+    }
+
+    if (randomBeaconApp.isAuthorized) {
+      selectedApps.filter(({ stakingAppId }) => stakingAppId !== "randomBeacon")
+    }
+  }, [tbtcApp.isAuthorized, randomBeaconApp.isAuthorized])
+
+  const tbtcMinAuthAmount = useStakingAppMinAuthorizationAmount("tbtc")
+  const randomBeaconMinAuthAmount =
+    useStakingAppMinAuthorizationAmount("randomBeacon")
+
+  const stake = useSelector((state: RootState) =>
+    selectStakeByStakingProvider(state, stakingProviderAddress!)
+  ) as StakeData
+
+  const isLoggedInAsAuthorizer =
+    stake && account ? isSameETHAddress(stake.authorizer, account) : false
+
+  const isInactiveStake = stake
+    ? BigNumber.from(stake?.totalInTStake).isZero()
+    : false
 
   const isAppSelected = (stakingAppName: AppAuthDataProps["stakingAppId"]) => {
     return selectedApps.map((app) => app.stakingAppId).includes(stakingAppName)

--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -123,7 +123,11 @@ const AuthorizeStakingAppsPage: FC = () => {
     }
 
     if (randomBeaconApp.isAuthorized) {
-      selectedApps.filter(({ stakingAppId }) => stakingAppId !== "randomBeacon")
+      setSelectedApps((selectedApps) =>
+        selectedApps.filter(
+          ({ stakingAppId }) => stakingAppId !== "randomBeacon"
+        )
+      )
     }
   }, [tbtcApp.isAuthorized, randomBeaconApp.isAuthorized])
 

--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -295,7 +295,7 @@ const AuthorizeStakingAppsPage: FC = () => {
             mt={5}
             onClick={onAuthorizeApps}
           >
-            Authorize selected apps
+            Authorize Selected Apps
           </Button>
         )}
       </Card>

--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -275,15 +275,17 @@ const AuthorizeStakingAppsPage: FC = () => {
             />
           </>
         )}
-        <Button
-          disabled={selectedApps.length === 0 || !isLoggedInAsAuthorizer}
-          variant="outline"
-          width="100%"
-          mt={5}
-          onClick={onAuthorizeApps}
-        >
-          Authorize selected apps
-        </Button>
+        {(!tbtcApp.isAuthorized || !randomBeaconApp.isAuthorized) && (
+          <Button
+            disabled={selectedApps.length === 0 || !isLoggedInAsAuthorizer}
+            variant="outline"
+            width="100%"
+            mt={5}
+            onClick={onAuthorizeApps}
+          >
+            Authorize selected apps
+          </Button>
+        )}
       </Card>
     </>
   ) : (


### PR DESCRIPTION
Closes: #244

This PR removes `Authorize Selected Apps` button if all apps have been authorized because there are no longer any more apps to select. It also fixes an issue with selected apps after authorization transaction- the authorized app was not removed from the `selectedApps` array so the user was able to click the `Authorize Selected Apps` again.