### PR TITLE
Stake details refresh bug fix

### DIFF
--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -215,6 +215,9 @@ const AuthorizeStakingAppsPage: FC = () => {
 
   const alertTextColor = useColorModeValue("gray.900", "white")
 
+  if (active && !stake)
+    return <div>No Stake found for address: {stakingProviderAddress} </div>
+
   return active ? (
     <>
       <Card>

--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -77,7 +77,7 @@ const AuthorizeStakingAppsPage: FC = () => {
     dispatch(
       requestStakeByStakingProvider({ stakingProvider: stakingProviderAddress })
     )
-  }, [stakingProviderAddress, account])
+  }, [stakingProviderAddress, account, dispatch])
 
   useEffect(() => {
     dispatch(stakingApplicationsSlice.actions.getSupportedApps({}))
@@ -216,7 +216,9 @@ const AuthorizeStakingAppsPage: FC = () => {
   const alertTextColor = useColorModeValue("gray.900", "white")
 
   if (active && !stake)
-    return <div>No Stake found for address: {stakingProviderAddress} </div>
+    return (
+      <BodyLg>No stake found for address: {stakingProviderAddress} </BodyLg>
+    )
 
   return active ? (
     <>

--- a/src/pages/Staking/StakeDetailsPage/index.tsx
+++ b/src/pages/Staking/StakeDetailsPage/index.tsx
@@ -1,5 +1,5 @@
 import { StakeData } from "../../../types"
-import { FC } from "react"
+import { FC, useEffect } from "react"
 import {
   Badge,
   BodyMd,
@@ -17,15 +17,34 @@ import InfoBox from "../../../components/InfoBox"
 import TokenBalance from "../../../components/TokenBalance"
 import StakeDetailRow from "./StakeDetailRow"
 import { StakeCardHeaderTitle } from "../StakeCard/Header/HeaderTitle"
-import { useParams } from "react-router-dom"
-import { selectStakeByStakingProvider } from "../../../store/staking"
+import { useNavigate, useParams } from "react-router-dom"
+import {
+  requestStakeByStakingProvider,
+  selectStakeByStakingProvider,
+} from "../../../store/staking"
 import { selectRewardsByStakingProvider } from "../../../store/rewards"
 import NodeStatusLabel from "./NodeStatusLabel"
 import { useStakingAppDataByStakingProvider } from "../../../hooks/staking-applications"
-import { useAppSelector } from "../../../hooks/store"
+import { useAppDispatch, useAppSelector } from "../../../hooks/store"
+import { useWeb3React } from "@web3-react/core"
+import { AddressZero } from "@ethersproject/constants"
+import { isAddress } from "web3-utils"
 
 const StakeDetailsPage: FC = () => {
   const { stakingProviderAddress } = useParams()
+  const { account, active } = useWeb3React()
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    if (!isAddress(stakingProviderAddress!)) navigate(`/staking`)
+  }, [stakingProviderAddress, navigate])
+
+  useEffect(() => {
+    dispatch(
+      requestStakeByStakingProvider({ stakingProvider: stakingProviderAddress })
+    )
+  }, [stakingProviderAddress, account])
 
   const stake = useAppSelector((state) =>
     selectStakeByStakingProvider(state, stakingProviderAddress!)
@@ -33,24 +52,24 @@ const StakeDetailsPage: FC = () => {
 
   const tbtcApp = useStakingAppDataByStakingProvider(
     "tbtc",
-    stake.stakingProvider
+    stakingProviderAddress || AddressZero
   )
 
   const randomBeaconApp = useStakingAppDataByStakingProvider(
     "randomBeacon",
-    stake.stakingProvider
+    stakingProviderAddress || AddressZero
   )
 
   const isInActiveStake = BigNumber.from(stake?.totalInTStake ?? "0").isZero()
 
   const { total: rewardsForStake } = useAppSelector((state) =>
-    selectRewardsByStakingProvider(state, stake.stakingProvider)
+    selectRewardsByStakingProvider(state, stakingProviderAddress!)
   )
 
-  if (!stake)
+  if (active && !stake)
     return <div>No Stake found for address: {stakingProviderAddress} </div>
 
-  return (
+  return active ? (
     <Card>
       <HStack justify="space-between">
         <H5>Stake Details</H5>
@@ -126,6 +145,8 @@ const StakeDetailsPage: FC = () => {
         </Stack>
       </SimpleGrid>
     </Card>
+  ) : (
+    <H5>{`Please connect your wallet.`}</H5>
   )
 }
 

--- a/src/pages/Staking/StakeDetailsPage/index.tsx
+++ b/src/pages/Staking/StakeDetailsPage/index.tsx
@@ -2,6 +2,7 @@ import { StakeData } from "../../../types"
 import { FC, useEffect } from "react"
 import {
   Badge,
+  BodyLg,
   BodyMd,
   Box,
   Card,
@@ -28,7 +29,7 @@ import { useStakingAppDataByStakingProvider } from "../../../hooks/staking-appli
 import { useAppDispatch, useAppSelector } from "../../../hooks/store"
 import { useWeb3React } from "@web3-react/core"
 import { AddressZero } from "@ethersproject/constants"
-import { isAddress } from "web3-utils"
+import { isAddress } from "../../../web3/utils"
 
 const StakeDetailsPage: FC = () => {
   const { stakingProviderAddress } = useParams()
@@ -44,7 +45,7 @@ const StakeDetailsPage: FC = () => {
     dispatch(
       requestStakeByStakingProvider({ stakingProvider: stakingProviderAddress })
     )
-  }, [stakingProviderAddress, account])
+  }, [stakingProviderAddress, account, dispatch])
 
   const stake = useAppSelector((state) =>
     selectStakeByStakingProvider(state, stakingProviderAddress!)
@@ -67,7 +68,7 @@ const StakeDetailsPage: FC = () => {
   )
 
   if (active && !stake)
-    return <div>No Stake found for address: {stakingProviderAddress} </div>
+    return <BodyLg>No Stake found for address: {stakingProviderAddress}</BodyLg>
 
   return active ? (
     <Card>

--- a/src/store/staking/effects.ts
+++ b/src/store/staking/effects.ts
@@ -55,6 +55,14 @@ const fetchStake = async (
       stakingProvider
     )
 
+  if (
+    isAddressZero(stake.owner) ||
+    isAddressZero(stake.beneficiary) ||
+    isAddressZero(stake.authorizer)
+  ) {
+    return
+  }
+
   listenerApi.dispatch(
     setStakes([
       {


### PR DESCRIPTION
There was a bug that prevented to load the Stake Details page if we refresh it orgo there by pasting a link - `/staking/<stakingProviderAddress>/details`

I've add additional logic to the component that resolves the issues.

Changes:
- use stakingProviderAddress from the url instead of the staking provider address from the fetched stake when loading stakingAppData (also use AddressZero if the address is undefined)
- navigate to `/staking` if the address provided in url is not an ETH address
- request stake by staking provider (similar to what we do in AuthorizeStakingApps page)
- add message to connect your wallet if the wallet is not connected
- display 'no stake found (...)` message only if wallet is connected and the stake does not exist
- don't dispatch `setStake` action in `fetchStake` effect if owner, beneficiary or authorizer is an AddressZero
- adds `No Stake found for address: <stakingProviderAddress>` message to the AuthorizeStakingApps page. The message will be displayed if the wallet is connected and the stake is not found (or when it's still fetching the stake).