### PR TITLE
Fix unrecognized Page Layout props

### DIFF
--- a/src/pages/Upgrade/index.tsx
+++ b/src/pages/Upgrade/index.tsx
@@ -4,7 +4,7 @@ import PageLayout from "../PageLayout"
 import { PageComponent } from "../../types"
 
 const UpgradePage: PageComponent = (props) => {
-  return <PageLayout {...props} />
+  return <PageLayout title={props.title} pages={props.pages} />
 }
 
 UpgradePage.route = {

--- a/src/pages/tBTC/index.tsx
+++ b/src/pages/tBTC/index.tsx
@@ -5,7 +5,7 @@ import TBTCBridge from "./Bridge"
 import { featureFlags } from "../../constants"
 
 const MainTBTCPage: PageComponent = (props) => {
-  return <PageLayout {...props} />
+  return <PageLayout title={props.title} pages={props.pages} />
 }
 
 MainTBTCPage.route = {


### PR DESCRIPTION
There were two warning in the console:
- Received `true` for a non-boolean attribute `index`,
- React does not recognize the `isPageEnabled` prop on a DOM element,

They were displayed on tbtc page and on upgrade page. It happened because we passed all the props from the `<component>.route` to the `PageLayout` component and they were used in the Container which does not recognize these props. This PR fixes that and removes the warnings.