### PR TITLE
Add the status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Threshold Token Dashboard
 
+[![Token Dashboard / CI](https://github.com/threshold-network/token-dashboard/actions/workflows/dashboard-ci.yml/badge.svg?branch=main&event=push)](https://github.com/threshold-network/token-dashboard/actions/workflows/dashboard-ci.yml)
+[![Docs](https://img.shields.io/badge/docs-website-green)](https://docs.threshold.network)
+[![Chat with us on Discord](https://img.shields.io/badge/chat-Discord-5865f2.svg)](https://discord.gg/threshold)
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 # Local development


### PR DESCRIPTION
We're adding the badges to the README file.
We've:
- added a chat badge to point to the Threshold Network Discord server
- added a docs badge linking to the Threshold Network documentation
- added a badge showing the status of the workflow building the dashboard. The displayed status is based on the status of the most recently executed `Token Dashboard / CI` workflow triggered by the push to `main`. Note that unike other badges this badge is created using native GH workflow status badge functionality - that's because `shields.io` doesn't support yet workflows using `/` character in their name (see https://github.com/badges/shields/issues/4559).