### PR TITLE
Improve Bridge page layout

### DIFF
--- a/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
@@ -89,10 +89,8 @@ export const MakeDeposit: FC = () => {
         />
 
         <HStack bg="white" borderRadius="lg" justify="space-between" px={4}>
-          <BodySm color="brand.500">
-            {isLargerThan1280
-              ? btcDepositAddress
-              : shortenAddress(btcDepositAddress)}
+          <BodySm color="brand.500" maxW={"xs"} isTruncated>
+            {btcDepositAddress}
           </BodySm>
           <CopyToClipboard textToCopy={btcDepositAddress} />
         </HStack>

--- a/src/pages/tBTC/Bridge/MintingCard/index.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/index.tsx
@@ -7,11 +7,36 @@ import { MintingFlowRouter } from "./MintingFlowRouter"
 export const MintingCard: FC<ComponentProps<typeof Card>> = ({ ...props }) => {
   return (
     <Card {...props}>
-      <Stack direction="row" divider={<StackDivider />} h="100%" spacing={8}>
-        <Box maxW="66%" width="100%">
+      <Stack
+        direction={{
+          base: "column",
+          md: "row",
+          lg: "column",
+          xl: "row",
+        }}
+        divider={<StackDivider />}
+        h="100%"
+        spacing={8}
+      >
+        <Box
+          w={{
+            base: "100%",
+            md: "66%",
+            lg: "100%",
+            xl: "66%",
+          }}
+        >
           <MintingFlowRouter />
         </Box>
-        <Box maxW="33%" minW={"216px"} w="100%">
+        <Box
+          w={{
+            base: "100%",
+            md: "33%",
+            lg: "100%",
+            xl: "33%",
+          }}
+          minW={"216px"}
+        >
           <MintingTimeline />
         </Box>
       </Stack>

--- a/src/pages/tBTC/Bridge/UnmintingCard/index.tsx
+++ b/src/pages/tBTC/Bridge/UnmintingCard/index.tsx
@@ -8,11 +8,36 @@ export const UnmintingCard: FC<ComponentProps<typeof Card>> = ({
 }) => {
   return (
     <Card {...props}>
-      <Stack direction="row" divider={<StackDivider />} h="100%" spacing={8}>
-        <Box maxW="66%" width="100%">
+      <Stack
+        direction={{
+          base: "column",
+          md: "row",
+          lg: "column",
+          xl: "row",
+        }}
+        divider={<StackDivider />}
+        h="100%"
+        spacing={8}
+      >
+        <Box
+          w={{
+            base: "100%",
+            md: "66%",
+            lg: "100%",
+            xl: "66%",
+          }}
+        >
           <UnmintingFlowRouter />
         </Box>
-        <Box maxW="33%" minW={"216px"} w="100%">
+        <Box
+          w={{
+            base: "100%",
+            md: "33%",
+            lg: "100%",
+            xl: "33%",
+          }}
+          minW={"216px"}
+        >
           <UnmintingTimeline />
         </Box>
       </Stack>

--- a/src/pages/tBTC/Bridge/index.tsx
+++ b/src/pages/tBTC/Bridge/index.tsx
@@ -1,4 +1,4 @@
-import { Grid, useMediaQuery } from "@threshold-network/components"
+import { HStack, useMediaQuery, VStack } from "@threshold-network/components"
 import { PageComponent } from "../../../types"
 import { TbtcBalanceCard } from "./TbtcBalanceCard"
 import { MintUnmintNav } from "./MintUnmintNav"
@@ -26,34 +26,26 @@ const TBTCBridge: PageComponent = (props) => {
   }, [isSmallerThan1280])
 
   return (
-    <Grid
-      maxW="1040px"
-      gridAutoColumns="minmax(0, 1fr)"
-      gridAutoFlow="column"
-      gridTemplate={{
-        base: `
-            "tbtc-balance           mint-nav      mint-nav      mint-nav"
-            "tbtc-balance           mint-card     mint-card     mint-card"
-            "transaction-history    mint-card     mint-card     mint-card"
-          `,
-        xl: `
-            "tbtc-balance           mint-nav      mint-nav      mint-nav"
-            "tbtc-balance           mint-card     mint-card     mint-card"
-            "transaction-history    mint-card     mint-card     mint-card"
-          `,
-      }}
-      gridGap="4"
+    <HStack
+      alignItems={{ base: "flex-end", lg: "flex-start" }}
+      w={"100%"}
+      flexDirection={{ base: "column", lg: "row" }}
+      spacing={4}
     >
-      <TbtcBalanceCard gridArea="tbtc-balance" />
-      <MintUnmintNav gridArea="mint-nav" />
-      <TransactionHistory gridArea="transaction-history" />
-      {mintingType === TbtcMintingType.mint && (
-        <MintingCard gridArea="mint-card" />
-      )}
-      {mintingType === TbtcMintingType.unmint && (
-        <UnmintingCard gridArea="mint-card" />
-      )}
-    </Grid>
+      <VStack
+        spacing={4}
+        mb={{ base: 10, xl: 0 }}
+        w={{ base: "100%", lg: "40%", xl: "25%" }}
+      >
+        <TbtcBalanceCard />
+        <TransactionHistory />
+      </VStack>
+      <VStack spacing={4} w={{ base: "100%", lg: "60%", xl: "75%" }}>
+        <MintUnmintNav w={"100%"} />
+        {mintingType === TbtcMintingType.mint && <MintingCard p={35} />}
+        {mintingType === TbtcMintingType.unmint && <UnmintingCard p={35} />}
+      </VStack>
+    </HStack>
   )
 }
 


### PR DESCRIPTION
We changed the grid layout to a stack layout in a Bridge page which will eliminate some of the UI bugs caused by the Grid:
- too long TBTC balance card on Step 2 (because of the grid two rows on the Bridge page were equal and thus it prolonged the TBTC balance card)
- (additionally) improved the UI looks on the resolution lower than 1280 px (xl). Right now we display the modal window that says that this page won't work on mobile devices on a resolution with width less than 1280px. This change makes the page responsive on all resolutions.

Also we added a truncate and a maxW property to a deposit address container. This will keep the rows in `MakeDeposit` container same width in step 1 and step 2 (and all the steps, but step 2 was the problem here).