### PR TITLE
Threshold lib updates

### DIFF
--- a/src/threshold-ts/index.ts
+++ b/src/threshold-ts/index.ts
@@ -2,11 +2,13 @@ import { MultiAppStaking } from "./mas"
 import { IMulticall, Multicall } from "./multicall"
 import { IStaking, Staking } from "./staking"
 import { ThresholdConfig } from "./types"
+import { IVendingMachines, VendingMachines } from "./vending-machine"
 
 export class Threshold {
   multicall!: IMulticall
   staking!: IStaking
   multiAppStaking!: MultiAppStaking
+  vendingMachines!: IVendingMachines
 
   constructor(config: ThresholdConfig) {
     this._initialize(config)
@@ -14,6 +16,7 @@ export class Threshold {
 
   private _initialize = (config: ThresholdConfig) => {
     this.multicall = new Multicall(config.ethereum)
+    this.vendingMachines = new VendingMachines(config.ethereum)
     this.staking = new Staking(config.ethereum, this.multicall)
     this.multiAppStaking = new MultiAppStaking(
       this.staking,

--- a/src/threshold-ts/index.ts
+++ b/src/threshold-ts/index.ts
@@ -17,7 +17,11 @@ export class Threshold {
   private _initialize = (config: ThresholdConfig) => {
     this.multicall = new Multicall(config.ethereum)
     this.vendingMachines = new VendingMachines(config.ethereum)
-    this.staking = new Staking(config.ethereum, this.multicall)
+    this.staking = new Staking(
+      config.ethereum,
+      this.multicall,
+      this.vendingMachines
+    )
     this.multiAppStaking = new MultiAppStaking(
       this.staking,
       this.multicall,

--- a/src/threshold-ts/staking/__test__/staking.test.ts
+++ b/src/threshold-ts/staking/__test__/staking.test.ts
@@ -1,13 +1,29 @@
 import { BigNumber, ContractTransaction, providers } from "ethers"
 import TokenStaking from "@threshold-network/solidity-contracts/artifacts/TokenStaking.json"
-import { IStaking, Staking } from ".."
-import { AddressZero, getContract } from "../../utils"
+import NuCypherStakingEscrow from "@threshold-network/solidity-contracts/artifacts/NuCypherStakingEscrow.json"
+import KeepTokenStaking from "@keep-network/keep-core/artifacts/TokenStaking.json"
+import { IStaking, Stake, StakeType, Staking } from ".."
+import {
+  AddressZero,
+  getContract,
+  ZERO,
+  getContractAddressFromTruffleArtifact,
+  getContractPastEvents,
+} from "../../utils"
 import { IMulticall } from "../../multicall"
+import {
+  IVendingMachines,
+  IVendingMachine,
+  ConversionToT,
+} from "../../vending-machine"
 
 jest.mock("../../utils", () => ({
   ...(jest.requireActual("../../utils") as {}),
   getContract: jest.fn(),
+  getContractAddressFromTruffleArtifact: jest.fn(),
+  getContractPastEvents: jest.fn(),
 }))
+
 jest.mock(
   "@threshold-network/solidity-contracts/artifacts/TokenStaking.json",
   () => ({
@@ -15,6 +31,19 @@ jest.mock(
     abi: [],
   })
 )
+
+jest.mock(
+  "@threshold-network/solidity-contracts/artifacts/NuCypherStakingEscrow.json",
+  () => ({
+    address: "0xd696d5a9b083959587F30e487038529a876b08C2",
+    abi: [],
+  })
+)
+
+jest.mock("@keep-network/keep-core/artifacts/TokenStaking.json", () => ({
+  address: "0x73A63e2Be2D911dc7eFAc189Bfdf48FbB6532B5b",
+  abi: [],
+}))
 
 describe("Staking test", () => {
   let staking: IStaking
@@ -25,6 +54,16 @@ describe("Staking test", () => {
     authorizedStake: jest.fn(),
     increaseAuthorization: jest.fn(),
   }
+
+  const mockLegacyKeepStaking = {
+    interface: {},
+    address: TokenStaking.address,
+  }
+  const mockLegacyNuStaking = {
+    interface: {},
+    address: TokenStaking.address,
+    stakerInfo: jest.fn(),
+  }
   const stakingProvider = "0x486b0ee2eed761f069f327034eb2ae5e07580bf3"
   const application = "0xE775aE21E40d34f01A5C0E1Db9FB3e637D768596"
   const mockedEthereumProvider = {} as providers.Provider
@@ -34,18 +73,52 @@ describe("Staking test", () => {
     account: AddressZero,
   }
 
+  const vendingMachines = {
+    nu: { convertToT: jest.fn() } as unknown as IVendingMachine,
+    keep: { convertToT: jest.fn() } as unknown as IVendingMachine,
+  } as IVendingMachines
+
+  const keepTokenStakingAddress = (
+    KeepTokenStaking as unknown as { address: string }
+  ).address
+
   beforeEach(() => {
-    ;(getContract as jest.Mock).mockImplementation(() => mockStakingContract)
+    ;(getContract as jest.Mock)
+      .mockImplementationOnce(() => mockStakingContract)
+      .mockImplementationOnce(() => mockLegacyKeepStaking)
+      .mockImplementationOnce(() => mockLegacyNuStaking)
+    ;(getContractAddressFromTruffleArtifact as jest.Mock).mockReturnValue(
+      keepTokenStakingAddress
+    )
     multicall = {
       aggregate: jest.fn(),
+      getCurrentBlockTimestampCallObj: jest.fn(),
     }
-    staking = new Staking(ethConfig, multicall)
+    staking = new Staking(ethConfig, multicall, vendingMachines)
   })
 
   test("should create the staking instance correctly", () => {
-    expect(getContract).toHaveBeenCalledWith(
+    expect(getContract).toHaveBeenNthCalledWith(
+      1,
       TokenStaking.address,
       TokenStaking.abi,
+      ethConfig.providerOrSigner,
+      ethConfig.account
+    )
+    expect(getContractAddressFromTruffleArtifact).toHaveBeenCalledWith(
+      KeepTokenStaking
+    )
+    expect(getContract).toHaveBeenNthCalledWith(
+      2,
+      keepTokenStakingAddress,
+      KeepTokenStaking.abi,
+      ethConfig.providerOrSigner,
+      ethConfig.account
+    )
+    expect(getContract).toHaveBeenNthCalledWith(
+      3,
+      NuCypherStakingEscrow.address,
+      NuCypherStakingEscrow.abi,
       ethConfig.providerOrSigner,
       ethConfig.account
     )
@@ -93,11 +166,33 @@ describe("Staking test", () => {
     }
     const amount = BigNumber.from("100")
     const stakes = { tStake: amount, keepInTStake: amount, nuInTStake: amount }
-    const multiCallResult = [rolesOf, stakes]
+    const eligibleKeepStake = amount.add("100")
+    const nuStakerInfo = {
+      stakingProvider: stakingProvider,
+      value: amount.add(300),
+    }
+    const keepToTConversion: ConversionToT = {
+      tAmount: BigNumber.from("110"),
+      wrappedRemainder: ZERO,
+    }
+    const nuToTConversion: ConversionToT = {
+      tAmount: BigNumber.from("120"),
+      wrappedRemainder: ZERO,
+    }
+
+    const multiCallResult = [rolesOf, stakes, eligibleKeepStake]
 
     const aggregateSpyOn = jest
       .spyOn(multicall, "aggregate")
       .mockResolvedValue(multiCallResult)
+
+    mockLegacyNuStaking.stakerInfo.mockResolvedValue(nuStakerInfo)
+    ;(vendingMachines.keep.convertToT as jest.Mock).mockResolvedValue(
+      keepToTConversion
+    )
+    ;(vendingMachines.nu.convertToT as jest.Mock).mockResolvedValue(
+      nuToTConversion
+    )
 
     const result = await staking.getStakeByStakingProvider(stakingProvider)
 
@@ -114,14 +209,78 @@ describe("Staking test", () => {
         method: "stakes",
         args: [stakingProvider],
       },
+      {
+        interface: mockLegacyKeepStaking.interface,
+        address: mockLegacyKeepStaking.address,
+        method: "eligibleStake",
+        args: [stakingProvider, mockStakingContract.address],
+      },
     ])
+
+    expect(vendingMachines.keep.convertToT).toHaveBeenCalledWith(
+      eligibleKeepStake
+    )
+    expect(vendingMachines.nu.convertToT).toHaveBeenCalledWith(
+      nuStakerInfo.value
+    )
+
     expect(result).toEqual({
+      stakeType: undefined,
       ...rolesOf,
       ...stakes,
       stakingProvider,
       totalInTStake: stakes.tStake
         .add(stakes.keepInTStake)
         .add(stakes.nuInTStake),
+      possibleKeepTopUpInT: keepToTConversion.tAmount.sub(stakes.keepInTStake),
+      possibleNuTopUpInT: nuToTConversion.tAmount.sub(stakes.nuInTStake),
     })
+  })
+
+  test("should return all stakes for a given owner address", async () => {
+    const owner = "0x97839202A818D2C927f7f44685c5a34f80FbcdB6"
+    const stakingProvider1 = stakingProvider
+    const stakingProvider2 = "0xad96829b90c8c2cbbe8e59dd3bf1c101c38cd822"
+    const stakingProvider3 = "0xd74Cf2a8b8DFc2CA74Be5f381c4c220238F63c58"
+
+    const mockPastEventsResult = [
+      { args: { stakingProvider: stakingProvider1, stakeType: StakeType.T } },
+      {
+        args: { stakingProvider: stakingProvider2, stakeType: StakeType.KEEP },
+      },
+      { args: { stakingProvider: stakingProvider3, stakeType: StakeType.NU } },
+    ]
+    ;(getContractPastEvents as jest.Mock).mockResolvedValue([
+      ...mockPastEventsResult,
+    ])
+
+    const mockStakes = [
+      { ...mockPastEventsResult[2].args, owner },
+      { ...mockPastEventsResult[1].args, owner },
+      { ...mockPastEventsResult[0].args, owner },
+    ] as Stake[]
+
+    const spyOnGetStakeByStakingProvider = jest
+      .spyOn(staking, "getStakeByStakingProvider")
+      .mockResolvedValueOnce(mockStakes[0])
+      .mockResolvedValueOnce(mockStakes[1])
+      .mockResolvedValueOnce(mockStakes[2])
+
+    const result = await staking.getOwnerStakes(owner)
+
+    expect(getContractPastEvents).toHaveBeenCalledWith(mockStakingContract, {
+      eventName: "Staked",
+      fromBlock: staking.STAKING_CONTRACT_DEPLOYMENT_BLOCK,
+      filterParams: [undefined, owner],
+    })
+
+    mockPastEventsResult.reverse().forEach((event, index) => {
+      expect(spyOnGetStakeByStakingProvider).toHaveBeenNthCalledWith(
+        index + 1,
+        event.args.stakingProvider,
+        event.args.stakeType
+      )
+    })
+    expect(result).toEqual(mockStakes)
   })
 })

--- a/src/threshold-ts/staking/index.ts
+++ b/src/threshold-ts/staking/index.ts
@@ -45,6 +45,7 @@ export interface RolesOf {
 
 export interface IStaking {
   stakingContract: Contract
+  STAKING_CONTRACT_DEPLOYMENT_BLOCK: number
   /**
    * Returns the authorized stake amount of the staking provider for the application.
    * @param stakingProvider Staking provider address.

--- a/src/threshold-ts/staking/index.ts
+++ b/src/threshold-ts/staking/index.ts
@@ -1,10 +1,30 @@
 import TokenStaking from "@threshold-network/solidity-contracts/artifacts/TokenStaking.json"
+import NuCypherStakingEscrow from "@threshold-network/solidity-contracts/artifacts/NuCypherStakingEscrow.json"
+import KeepTokenStaking from "@keep-network/keep-core/artifacts/TokenStaking.json"
 import { BigNumber, BigNumberish, Contract, ContractTransaction } from "ethers"
 import { ContractCall, IMulticall } from "../multicall"
 import { EthereumConfig } from "../types"
-import { getContract } from "../utils"
+import {
+  getContract,
+  getContractAddressFromTruffleArtifact,
+  getContractPastEvents,
+  isAddress,
+  isSameETHAddress,
+  ZERO,
+} from "../utils"
+import { IVendingMachines } from "../vending-machine"
+
+// Note: Must be in the same order as here:
+// https://github.com/threshold-network/solidity-contracts/blob/main/contracts/staking/IStaking.sol#L30-L
+// because solidity eg. for `StakeType.NU` returns 0.
+export enum StakeType {
+  NU,
+  KEEP,
+  T,
+}
 
 export interface Stake<NumberType extends BigNumberish = BigNumber> {
+  stakeType?: StakeType
   owner: string
   stakingProvider: string
   beneficiary: string
@@ -13,7 +33,8 @@ export interface Stake<NumberType extends BigNumberish = BigNumber> {
   keepInTStake: NumberType
   tStake: NumberType
   totalInTStake: NumberType
-  // TODO: add `possibleKeepTopUpInT` and `possibleNuTopUpInT`.
+  possibleKeepTopUpInT: NumberType
+  possibleNuTopUpInT: NumberType
 }
 
 export interface RolesOf {
@@ -71,21 +92,48 @@ export interface IStaking {
    */
   rolesOf(stakingProvider: string): Promise<RolesOf>
 
-  // TODO: move other functions here eg fetching all owner stakes.
+  /**
+   * Returns all stakes for the given owner address.
+   * @param owner The stake owner address
+   * @returns All stakes for a given owner address.
+   */
+  getOwnerStakes(owner: string): Promise<Array<Stake>>
 }
 
 export class Staking implements IStaking {
   private _staking: Contract
   private _multicall: IMulticall
+  private _legacyKeepStaking: Contract
+  private _legacyNuStaking: Contract
+  private _vendingMachines: IVendingMachines
+  public readonly STAKING_CONTRACT_DEPLOYMENT_BLOCK: number
 
-  constructor(config: EthereumConfig, multicall: IMulticall) {
+  constructor(
+    config: EthereumConfig,
+    multicall: IMulticall,
+    vendingMachines: IVendingMachines
+  ) {
+    this.STAKING_CONTRACT_DEPLOYMENT_BLOCK = config.chainId === 1 ? 14113768 : 0
     this._staking = getContract(
       TokenStaking.address,
       TokenStaking.abi,
       config.providerOrSigner,
       config.account
     )
+    this._legacyKeepStaking = getContract(
+      getContractAddressFromTruffleArtifact(KeepTokenStaking),
+      KeepTokenStaking.abi,
+      config.providerOrSigner,
+      config.account
+    )
+    this._legacyNuStaking = getContract(
+      NuCypherStakingEscrow.address,
+      NuCypherStakingEscrow.abi,
+      config.providerOrSigner,
+      config.account
+    )
     this._multicall = multicall
+    this._vendingMachines = vendingMachines
   }
 
   async authorizedStake(
@@ -112,7 +160,8 @@ export class Staking implements IStaking {
   }
 
   getStakeByStakingProvider = async (
-    stakingProvider: string
+    stakingProvider: string,
+    stakeType?: StakeType
   ): Promise<Stake> => {
     const multicalls: ContractCall[] = [
       {
@@ -127,16 +176,43 @@ export class Staking implements IStaking {
         method: "stakes",
         args: [stakingProvider],
       },
+      {
+        interface: this._legacyKeepStaking.interface,
+        address: this._legacyKeepStaking.address,
+        method: "eligibleStake",
+        args: [stakingProvider, this._staking.address],
+      },
     ]
 
-    const [rolesOf, stakes] = await this._multicall.aggregate(multicalls)
+    const [rolesOf, stakes, eligibleKeepStake] =
+      await this._multicall.aggregate(multicalls)
 
     const { owner, authorizer, beneficiary } = rolesOf
 
     const { tStake, keepInTStake, nuInTStake } = stakes
+
+    // The NU staker can have only one stake.
+    const { stakingProvider: nuStakingProvider, value: nuStake } =
+      await this._legacyNuStaking.stakerInfo(owner)
+    const possibleNuTopUpInT =
+      isAddress(nuStakingProvider) &&
+      isSameETHAddress(stakingProvider, nuStakingProvider)
+        ? BigNumber.from(
+            (await this._vendingMachines.nu.convertToT(nuStake)).tAmount
+          ).sub(BigNumber.from(nuInTStake))
+        : ZERO
+
+    const keepEligableStakeInT = (
+      await this._vendingMachines.keep.convertToT(eligibleKeepStake)
+    ).tAmount
+    const possibleKeepTopUpInT = BigNumber.from(keepEligableStakeInT).sub(
+      BigNumber.from(keepInTStake)
+    )
+
     const totalInTStake = tStake.add(keepInTStake).add(nuInTStake)
 
     return {
+      stakeType,
       owner,
       authorizer,
       beneficiary,
@@ -145,6 +221,8 @@ export class Staking implements IStaking {
       keepInTStake,
       nuInTStake,
       totalInTStake,
+      possibleKeepTopUpInT,
+      possibleNuTopUpInT,
     }
   }
 
@@ -165,5 +243,24 @@ export class Staking implements IStaking {
       beneficiary: rolesOf.beneficiary,
       authorizer: rolesOf.authorizer,
     }
+  }
+
+  getOwnerStakes = async (owner: string): Promise<Array<Stake>> => {
+    const stakedEvents = (
+      await getContractPastEvents(this._staking, {
+        eventName: "Staked",
+        fromBlock: this.STAKING_CONTRACT_DEPLOYMENT_BLOCK,
+        filterParams: [undefined, owner],
+      })
+    ).reverse()
+
+    return await Promise.all(
+      stakedEvents.map((stakedEvent) =>
+        this.getStakeByStakingProvider(
+          stakedEvent.args?.stakingProvider,
+          stakedEvent.args?.stakeType
+        )
+      )
+    )
   }
 }

--- a/src/threshold-ts/utils/constants.ts
+++ b/src/threshold-ts/utils/constants.ts
@@ -2,3 +2,5 @@ import { BigNumber, constants } from "ethers"
 
 export const MAX_UINT64 = BigNumber.from("18446744073709551615") // 2^64 - 1
 export const ZERO = constants.Zero
+
+export const STANDARD_ERC20_DECIMALS = 18

--- a/src/threshold-ts/utils/contract.ts
+++ b/src/threshold-ts/utils/contract.ts
@@ -1,6 +1,6 @@
-import { JsonRpcSigner, Web3Provider } from "@ethersproject/providers"
-import { Contract, ContractInterface, providers, Signer } from "ethers"
-import { getAddress, isAddressZero } from "./address"
+import { JsonRpcSigner, Web3Provider, BlockTag } from "@ethersproject/providers"
+import { Contract, ContractInterface, providers, Signer, Event } from "ethers"
+import { AddressZero, getAddress, isAddressZero } from "./address"
 
 // account is not optional
 export function getSigner(
@@ -32,4 +32,37 @@ export const getContract = (
     abi,
     getProviderOrSigner(providerOrSigner as any, account) as any
   )
+}
+
+interface EventFilterOptions {
+  fromBlock?: BlockTag
+  toBlock?: BlockTag
+  filterParams: any[]
+  eventName: string
+}
+
+export const getContractPastEvents = async (
+  contract: Contract,
+  options: EventFilterOptions
+): Promise<Array<Event>> => {
+  const filter = contract.filters[options.eventName](...options.filterParams)
+
+  return await contract.queryFilter(filter, options.fromBlock, options.toBlock)
+}
+
+export function getContractAddressFromTruffleArtifact(
+  truffleArtifact: { networks: { [chainID: string]: { address: string } } },
+  chainID: string | undefined = undefined
+) {
+  const networks = Object.keys(truffleArtifact.networks) as Array<
+    keyof typeof truffleArtifact.networks
+  >
+
+  return networks && networks.length > 0
+    ? (
+        truffleArtifact.networks[chainID ? chainID : networks[0]] as {
+          address: string
+        }
+      ).address
+    : AddressZero
 }

--- a/src/threshold-ts/vending-machine/__tests__/vending-machine.test.ts
+++ b/src/threshold-ts/vending-machine/__tests__/vending-machine.test.ts
@@ -1,0 +1,106 @@
+import { BigNumber, providers } from "ethers"
+import { IVendingMachine, VendingMachine } from ".."
+import { EthereumConfig } from "../../types"
+import { getContract, ZERO } from "../../utils"
+
+jest.mock("../../utils", () => ({
+  ...(jest.requireActual("../../utils") as {}),
+  getContract: jest.fn(),
+}))
+
+describe("Vending machine test", () => {
+  let vendingMachine: IVendingMachine
+  let config: EthereumConfig
+  let artifact: { abi: any; address: string }
+  const ratio = BigNumber.from("4783188631255016")
+  const mockVendingMachineContract = {
+    ratio: jest.fn(),
+  }
+
+  beforeEach(() => {
+    config = {
+      chainId: 1,
+      providerOrSigner: {} as providers.Provider,
+      account: "0x6B2896f915122660163e3a17f54BC244312212FD",
+    }
+    artifact = {
+      abi: [],
+      address: "0x2D8E01C35426780f2BCc859fC386eDEf61831386",
+    }
+    ;(getContract as jest.Mock).mockImplementation(
+      () => mockVendingMachineContract
+    )
+    vendingMachine = new VendingMachine(config, artifact)
+  })
+
+  test("should create the vending machine instance correctly", () => {
+    expect(getContract).toHaveBeenCalledWith(
+      artifact.address,
+      artifact.abi,
+      config.providerOrSigner,
+      config.account
+    )
+    expect(vendingMachine.contract).toEqual(mockVendingMachineContract)
+  })
+
+  describe("fetching ratio test", () => {
+    beforeEach(() => {
+      mockVendingMachineContract.ratio.mockResolvedValue(ratio)
+    })
+
+    test("should fetch the ratio from chain", async () => {
+      const result = await vendingMachine.ratio()
+
+      expect(mockVendingMachineContract.ratio).toHaveBeenCalled()
+      expect(result).toEqual(ratio)
+    })
+
+    test("should return a cached ratio value if the ratio has already been fetched", async () => {
+      const result1 = await vendingMachine.ratio()
+      const result2 = await vendingMachine.ratio()
+
+      expect(mockVendingMachineContract.ratio).toHaveBeenCalledTimes(1)
+      expect(result1).toEqual(ratio)
+      expect(result2).toEqual(ratio)
+      expect(result1).toEqual(result2)
+    })
+  })
+
+  describe("conversion to T test", () => {
+    let spyOnRatio: jest.SpyInstance<Promise<BigNumber>>
+
+    beforeEach(() => {
+      spyOnRatio = jest
+        .spyOn(vendingMachine, "ratio")
+        .mockResolvedValueOnce(ratio)
+    })
+
+    test("should convert wrapped token amount correctly", async () => {
+      const wrappedTokenAmount = "1000000000000000000" // 1
+      const expectedTValue = BigNumber.from("4783188631255016000")
+
+      const result = await vendingMachine.convertToT(wrappedTokenAmount)
+
+      expect(spyOnRatio).toHaveBeenCalled()
+      expect(result).toEqual({
+        tAmount: expectedTValue,
+        wrappedRemainder: ZERO,
+      })
+    })
+
+    test("should convert wrapped token amount only to 3 decimals precision", async () => {
+      const wrappedTokenAmount = "442210061406893004115226"
+      const expectedTValue = BigNumber.from("2115174136401787131915976")
+      const wrappedRemainder = BigNumber.from(wrappedTokenAmount).mod(
+        vendingMachine.FLOATING_POINT_DIVISOR
+      )
+
+      const result = await vendingMachine.convertToT(wrappedTokenAmount)
+      expect(spyOnRatio).toHaveBeenCalled()
+      expect(result).toEqual({
+        tAmount: expectedTValue,
+        wrappedRemainder,
+      })
+    })
+  })
+})

--- a/src/threshold-ts/vending-machine/index.ts
+++ b/src/threshold-ts/vending-machine/index.ts
@@ -1,0 +1,117 @@
+import VendingMachineKeep from "@threshold-network/solidity-contracts/artifacts/VendingMachineKeep.json"
+import VendingMachineNuCypher from "@threshold-network/solidity-contracts/artifacts/VendingMachineNuCypher.json"
+import { BigNumber, BigNumberish, Contract } from "ethers"
+import { EthereumConfig } from "../types"
+import { getContract, STANDARD_ERC20_DECIMALS } from "../utils"
+
+export interface ConversionToT<NumberType extends BigNumberish = BigNumber> {
+  tAmount: NumberType
+  wrappedRemainder: NumberType
+}
+
+/**
+ * Interface of update protocol to enable KEEP/NU token holders to wrap their
+ * tokens and obtain T tokens according to a fixed ratio.
+ */
+export interface IVendingMachine {
+  /**
+   * Number of decimal places of precision in conversion to/from wrapped tokens
+   * (assuming typical ERC20 token with 18 decimals). This implies that amounts
+   * of wrapped tokens below this precision won't take part in the conversion.
+   * E.g., for a value of 3, then for a conversion of 1.123456789 wrapped
+   * tokens, only 1.123 is convertible (i.e., 3 decimal places), and 0.000456789
+   * is left.
+   */
+  WRAPPED_TOKEN_CONVERSION_PRECISION: number
+
+  /**
+   * Divisor for precision purposes, used to represent fractions.
+   */
+  FLOATING_POINT_DIVISOR: BigNumber
+
+  /**
+   * Ethers contract instance of the `VendingMachine` contract.
+   */
+  contract: Contract
+
+  /**
+   * Returns the T token amount that's obtained from `amount` wrapped tokens,
+   * and the remainder that can't be upgraded.
+   * @param amount Amount of the wrapped token to convert to T.
+   * @returns Object representing the T token amount and the reminder that can't
+   * be upgraded @see {@link ConversionToT}
+   */
+  convertToT(amount: string): Promise<ConversionToT>
+
+  /**
+   * @returns The ratio with which T token is converted based on the provided
+   * token being wrapped, expressed in 1e18 precision.
+   */
+  ratio(): Promise<BigNumber>
+}
+
+/**
+ * Interface of vending machines in T network. There is a separate instance of
+ * the vending machine for KEEP holders and a separate instance of the vending
+ * machine for NU holders.
+ */
+export interface IVendingMachines {
+  nu: IVendingMachine
+  keep: IVendingMachine
+}
+
+export class VendingMachine implements IVendingMachine {
+  private _vendingMachine: Contract
+  private _ratio?: BigNumber
+  public readonly WRAPPED_TOKEN_CONVERSION_PRECISION = 3
+  public readonly FLOATING_POINT_DIVISOR = BigNumber.from(10).pow(
+    BigNumber.from(
+      STANDARD_ERC20_DECIMALS - this.WRAPPED_TOKEN_CONVERSION_PRECISION
+    )
+  )
+
+  constructor(config: EthereumConfig, artifact: { abi: any; address: string }) {
+    this._vendingMachine = getContract(
+      artifact.address,
+      artifact.abi,
+      config.providerOrSigner,
+      config.account
+    )
+  }
+
+  get contract() {
+    return this._vendingMachine
+  }
+
+  ratio = async (): Promise<BigNumber> => {
+    if (!this._ratio) {
+      this._ratio = await this._vendingMachine.ratio()
+    }
+
+    return this._ratio!
+  }
+
+  convertToT = async (amount: string): Promise<ConversionToT> => {
+    const wrappedRemainder = BigNumber.from(amount).mod(
+      this.FLOATING_POINT_DIVISOR
+    )
+    const convertibleAmount = BigNumber.from(amount).sub(wrappedRemainder)
+
+    return {
+      tAmount: convertibleAmount
+        .mul(BigNumber.from(await this.ratio()))
+        .div(this.FLOATING_POINT_DIVISOR),
+      wrappedRemainder,
+    }
+  }
+}
+
+export class VendingMachines implements IVendingMachines {
+  public readonly nu: IVendingMachine
+  public readonly keep: IVendingMachine
+
+  constructor(config: EthereumConfig) {
+    this.nu = new VendingMachine(config, VendingMachineNuCypher)
+    this.keep = new VendingMachine(config, VendingMachineKeep)
+  }
+}

--- a/src/threshold-ts/vending-machine/index.ts
+++ b/src/threshold-ts/vending-machine/index.ts
@@ -3,9 +3,18 @@ import VendingMachineNuCypher from "@threshold-network/solidity-contracts/artifa
 import { BigNumber, BigNumberish, Contract } from "ethers"
 import { EthereumConfig } from "../types"
 import { getContract, STANDARD_ERC20_DECIMALS } from "../utils"
-
+/**
+ * An interface representing the T token amount and the reminder that can't be
+ * upgraded.
+ */
 export interface ConversionToT<NumberType extends BigNumberish = BigNumber> {
+  /**
+   * The amount of T tokens obtained from the amount of wrapped tokens.
+   */
   tAmount: NumberType
+  /**
+   * Amount of wrapped token that can't be upgraded.
+   */
   wrappedRemainder: NumberType
 }
 

--- a/src/utils/getContract.ts
+++ b/src/utils/getContract.ts
@@ -1,19 +1,5 @@
-import { AddressZero } from "../web3/utils/address"
-export { getSigner, getContract } from "../threshold-ts/utils/contract"
-
-export function getContractAddressFromTruffleArtifact(
-  truffleArtifact: { networks: { [chainID: string]: { address: string } } },
-  chainID: string | undefined = undefined
-) {
-  const networks = Object.keys(truffleArtifact.networks) as Array<
-    keyof typeof truffleArtifact.networks
-  >
-
-  return networks && networks.length > 0
-    ? (
-        truffleArtifact.networks[chainID ? chainID : networks[0]] as {
-          address: string
-        }
-      ).address
-    : AddressZero
-}
+export {
+  getSigner,
+  getContract,
+  getContractAddressFromTruffleArtifact,
+} from "../threshold-ts/utils/contract"

--- a/src/web3/utils/events.ts
+++ b/src/web3/utils/events.ts
@@ -1,18 +1,1 @@
-import { Contract, Event } from "@ethersproject/contracts"
-import { BlockTag } from "@ethersproject/abstract-provider"
-
-interface Options {
-  fromBlock?: BlockTag
-  toBlock?: BlockTag
-  filterParams: any[]
-  eventName: string
-}
-
-export const getContractPastEvents = async (
-  contract: Contract,
-  options: Options
-): Promise<Array<Event>> => {
-  const filter = contract.filters[options.eventName](...options.filterParams)
-
-  return await contract.queryFilter(filter, options.fromBlock, options.toBlock)
-}
+export { getContractPastEvents } from "../../threshold-ts/utils"


### PR DESCRIPTION
This PR moves the contract integration part from hooks to the Threshold-ts library. Thanks to this layer we can separate work between UI and contract integration. Also, it helps to unit test created services and move the "business logic" from the React hooks.

## Main changes in Threshold-ts lib

### Vending Machine
An interface of the wrapper for fetching on-chain data from the `VendingMachine` contract- the interface of update protocol to enable KEEP/NU token holders to wrap their tokens and obtain T tokens according to a fixed ratio. The Threshold lib creates a separate instance of the vending machine for KEEP holders and a separate instance of the vending machine for NU holders. Service covered with unit tests.

### Staking
Adds function `getOwnerStakes` that fetches all stakes for a given owner address. Here we add legacy Keep and Nu staking contracts as private fields to the `Staking` service to calculate possible KEEP/NU top-up in T. Also pass Keep and Nu vending machines to convert KEEP/NU amount to T.

### Utils functions
Move some contract-related utils functions from dashboard to the Threshold-ts lib.