### PR TITLE
Fix `non-serializable value in the state` error

### DIFF
--- a/src/components/Modal/TbtcRecoveryFileModal/index.tsx
+++ b/src/components/Modal/TbtcRecoveryFileModal/index.tsx
@@ -18,14 +18,15 @@ import withBaseModal from "../withBaseModal"
 import ViewInBlockExplorer from "../../ViewInBlockExplorer"
 import { ExplorerDataType } from "../../../utils/createEtherscanLink"
 import { useTbtcState } from "../../../hooks/useTbtcState"
+import { DepositScriptParameters } from "@keep-network/tbtc-v2.ts/dist/deposit"
+import { MintingStep } from "../../../types/tbtc"
+import { downloadFile } from "../../../web3/utils"
 
 const TbtcRecoveryFileModalModal: FC<
   BaseModalProps & {
-    jsonData: any
-    handleDownloadClick: any
-    handleDoubleReject: () => void
+    jsonData: DepositScriptParameters
   }
-> = ({ closeModal, jsonData, handleDownloadClick, handleDoubleReject }) => {
+> = ({ jsonData, closeModal }) => {
   const { isOpen: isOnConfirmStep, onOpen: setIsOnConfirmStep } =
     useDisclosure()
   const { updateState } = useTbtcState()
@@ -33,6 +34,22 @@ const TbtcRecoveryFileModalModal: FC<
   const titleText = isOnConfirmStep
     ? "Are you sure you do not want to download the .JSON file?"
     : "Download this JSON file"
+
+  const handleJsonDownload = () => {
+    downloadFile(
+      JSON.stringify(jsonData),
+      "deposit-script-parameters.json",
+      "text/json"
+    )
+
+    updateState("mintingStep", MintingStep.Deposit)
+    closeModal()
+  }
+
+  const handleDoubleReject = () => {
+    updateState("mintingStep", MintingStep.Deposit)
+    closeModal()
+  }
 
   const bodyContent = isOnConfirmStep ? (
     <BodyLg>
@@ -78,7 +95,7 @@ const TbtcRecoveryFileModalModal: FC<
             Cancel
           </Button>
         )}
-        <Button onClick={() => handleDownloadClick(jsonData)}>Download</Button>
+        <Button onClick={handleJsonDownload}>Download</Button>
       </ModalFooter>
     </>
   )

--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -75,23 +75,7 @@ const MintingProcessForm = withFormik<MintingProcessFormProps, FormValues>({
 export const ProvideData: FC = () => {
   const { updateState, ethAddress, btcRecoveryAddress } = useTbtcState()
   const formRef = useRef<FormikProps<FormValues>>(null)
-  const { openModal, closeModal } = useModal()
-
-  const handleJsonDownload = (data: DepositScriptParameters) => {
-    downloadFile(
-      JSON.stringify(data),
-      "deposit-script-parameters.json",
-      "text/json"
-    )
-
-    closeModal()
-    updateState("mintingStep", MintingStep.Deposit)
-  }
-
-  const handleDoubleReject = () => {
-    updateState("mintingStep", MintingStep.Deposit)
-    closeModal()
-  }
+  const { openModal } = useModal()
 
   const onSubmit = async (values: FormValues) => {
     // check if the user has changed the eth or btc address from the previous attempt
@@ -126,8 +110,6 @@ export const ProvideData: FC = () => {
       // if the user has NOT declined the json file, ask the user if they want to accept the new file
       openModal(ModalType.TbtcRecoveryJson, {
         jsonData: depositScriptParameters,
-        handleDownloadClick: handleJsonDownload,
-        handleDoubleReject,
       })
     }
 


### PR DESCRIPTION
There was an error in the console when clicking `Generate deposit address` on tbtc page:

`A non-serializable value was detected in the state`

<img width="1062" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/40306834/201669313-d45bd7cc-9e62-4d60-8336-4a067957c44c.png">

This happened because we passed non-serializable values (in this case functions - `handleJsonDownload` and `handleDoubleReject`) as a parameters through a redux action.

This PR moves those two function straight into the `TbtcRecoveryJson` modal.