### PR TITLE
Refactor custom impl of `useLocalStorage` hook

### DIFF
--- a/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/hooks/__tests__/useLocalStorage.test.ts
@@ -29,7 +29,6 @@ describe("Test `useLocalStorage` hook", () => {
 
     expect(result.current[0]).toEqual(value)
     expect(getItemSpy).toHaveBeenCalledWith(key)
-    expect(mockedLocalStorageState[key]).toEqual(JSON.stringify(value))
   })
 
   test("should save data in local storage and return updated value", () => {
@@ -76,15 +75,13 @@ describe("Test `useLocalStorage` hook", () => {
     const { result } = renderHook(() => useLocalStorage(key, value))
 
     expect(result.current[0]).toEqual(value)
-    expect(mockedLocalStorageState[key]).toEqual(JSON.stringify(value))
   })
 
   test("can have a string default value", () => {
     const value = "string"
-    const key = "numeric-value"
+    const key = "string-value"
     const { result } = renderHook(() => useLocalStorage(key, value))
 
     expect(result.current[0]).toEqual(value)
-    expect(mockedLocalStorageState[key]).toEqual(JSON.stringify(value))
   })
 })

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,9 +1,9 @@
-import { useLocalStorage } from "@rehooks/local-storage"
+import { useLocalStorage } from "../hooks/useLocalStorage"
 
 export const useAnalytics = () => {
   const [isAnalyticsEnabled, setIsAnalyticsEnabled] = useLocalStorage<
     boolean | undefined
-  >("isAnalyticsEnabled")
+  >("isAnalyticsEnabled", undefined)
 
   const enableAnalytics = () => {
     setIsAnalyticsEnabled(true)

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,54 +1,5 @@
-import { useEffect, useState } from "react"
-import { EventEmitter } from "events"
+import { useLocalStorage as useRehooksLocalStorage } from "@rehooks/local-storage"
 
-const localStorageEmitter = new EventEmitter()
-
-const getStorageValue = <T>(key: string | null, defaultValue: T) => {
-  if (!key) {
-    return defaultValue
-  }
-  const item = window.localStorage.getItem(key)
-  return item ? JSON.parse(item) : defaultValue
-}
-
-export const useLocalStorage = <T>(
-  key: string | null,
-  defaultValue: T
-): [T, (value: T) => void] => {
-  const [value, setValue] = useState(getStorageValue(key, defaultValue))
-
-  useEffect(() => {
-    if (key) {
-      try {
-        setValue(getStorageValue(key, defaultValue))
-      } catch (error) {
-        console.error(`Could not read local storage key  "${key}":`, error)
-        setValue(defaultValue)
-      }
-    }
-    // eslint-disable-next-line
-  }, [key, JSON.stringify(defaultValue)])
-
-  useEffect(() => {
-    if (key) {
-      localStorageEmitter.emit("value_changed", key, value)
-      localStorage.setItem(key, JSON.stringify(value))
-    }
-    // eslint-disable-next-line
-  }, [key, JSON.stringify(value)])
-
-  useEffect(() => {
-    const callback = (emittedKey: string, value: T) => {
-      if (key === emittedKey) {
-        setValue(value)
-      }
-    }
-    localStorageEmitter.on("value_changed", callback)
-
-    return () => {
-      localStorageEmitter.off("value_changed", callback)
-    }
-  }, [key])
-
-  return [value, setValue]
+export const useLocalStorage = <T>(key: string, defaultValue: T) => {
+  return useRehooksLocalStorage(key, defaultValue)
 }


### PR DESCRIPTION
Depends on: #323

Use hook from `@rehooks/local-storage` in our wrapper `useLocalStorage`
so we will use the new implementation in all places and we will have a
nice wrapper for external lib.