### PR TITLE
Temporarily use `@keep-network/coverage-pools@1.1.0-dev.7` dependency

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -80,7 +80,7 @@ jobs:
             @keep-network/tbtc-v2 \
             @keep-network/tbtc-v2.ts \
             @keep-network/ecdsa \
-            @keep-network/random-beacon
+            @keep-network/random-beacon --ignore-scripts
 
       - name: Run postinstall script
         # `yarn upgrade` doesn't trigger the `postinstall` script.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@ethersproject/constants": "^5.5.0",
     "@ethersproject/hardware-wallets": "^5.5.0",
     "@fontsource/inter": "^4.5.10",
-    "@keep-network/coverage-pools": "development",
+    "@keep-network/coverage-pools": "1.1.0-dev.7",
     "@keep-network/ecdsa": ">2.1.0-dev <2.1.0-goerli",
     "@keep-network/keep-core": "development",
     "@keep-network/keep-ecdsa": "development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,7 +3411,7 @@
   resolved "https://registry.yarnpkg.com/@keep-network/bitcoin-spv-sol/-/bitcoin-spv-sol-3.4.0-solc-0.8.tgz#8b44c246ffab8ea993efe196f6bf385b1a3b84dc"
   integrity sha512-KlpY9BbasyLvYXSS7dsJktgRChu/yjdFLOX8ldGA/pltLicCm/l0F4oqxL8wSws9XD12vq9x0B5qzPygVLB2TQ==
 
-"@keep-network/coverage-pools@development":
+"@keep-network/coverage-pools@1.1.0-dev.7":
   version "1.1.0-dev.7"
   resolved "https://registry.yarnpkg.com/@keep-network/coverage-pools/-/coverage-pools-1.1.0-dev.7.tgz#9973de59f5117d2f9165d82d5b5c16624276780d"
   integrity sha512-KTFpg3mUTD7NIG2yCTFRAyE2jTMe9gamegjxUmXDCq9kLRk1a9n5T5jW33hi4K4ujHgOuPGGMh9HnKj+yXQLOQ==


### PR DESCRIPTION
We're temporarily fixing the `@keep-network/coverage-pools` dashboard dependency to `1.1.0-dev.7` version. This is because at the moment we don't need changes from the higher versions and those higher versions (`2.2.0-dev.x`) are causing failures in CI when `yarn upgrade @keep-network/coverage-pools` gets executed. Until we figure out what's causing those problems and fix it, we will use latest non-problematic version (`1.1.0-dev.7`).

We're also adding `--ignore-scripts` flag to another step of CI.
When the flag is not used, the `Resolve latest contracts` step in
`dashboard-ci.yml` is failing during execution of
`./scripts/prepare-dependencies.sh` post-install script from
`@threshold-network/solidity-contracts` package. The problem is likely related
to the way Yarn deals with dependencies in `node_modules` - sometimes the tree
of dependencies is missing some leafs (packages), if the same package is used by
several modules. This means that the `prepare-dependencies.sh` script executed
in some path in `node_modules` may not find the artifacts from other module by
using relative paths (as the module may be stored in different place that the
script is expecting). Thanks to using `--ignore-scripts` flag, the post-install
scripts are not executed. Note that this flag prevents from executing all
post-install scripts, in all dependencies. We haven't observed any issues with
using it in `token-dashboard` so far.