### PR TITLE
tBTCv2 UI improvements

### DIFF
--- a/src/components/Modal/TbtcRecoveryFileModal/index.tsx
+++ b/src/components/Modal/TbtcRecoveryFileModal/index.tsx
@@ -14,13 +14,12 @@ import InfoBox from "../../InfoBox"
 import { BaseModalProps } from "../../../types"
 import btcJsonFile from "../../../static/images/tbtc-json-file.png"
 import withBaseModal from "../withBaseModal"
-import ViewInBlockExplorer from "../../ViewInBlockExplorer"
-import { ExplorerDataType } from "../../../utils/createEtherscanLink"
 import { useTbtcState } from "../../../hooks/useTbtcState"
 import { DepositScriptParameters } from "@keep-network/tbtc-v2.ts/dist/deposit"
 import { MintingStep } from "../../../types/tbtc"
 import { downloadFile } from "../../../web3/utils"
-import { useTBTCBridgeContractAddress } from "../../../hooks/useTBTCBridgeContractAddress"
+import Link from "../../Link"
+import { ExternalHref } from "../../../enums"
 
 const TbtcRecoveryFileModalModal: FC<
   BaseModalProps & {
@@ -29,7 +28,6 @@ const TbtcRecoveryFileModalModal: FC<
 > = ({ closeModal, depositScriptParameters }) => {
   const { isOpen: isOnConfirmStep, onOpen: setIsOnConfirmStep } =
     useDisclosure()
-  const bridgeContractAddress = useTBTCBridgeContractAddress()
   const { updateState } = useTbtcState()
 
   const handleDoubleReject = () => {
@@ -81,11 +79,9 @@ const TbtcRecoveryFileModalModal: FC<
         <Image mt="14" mb="16" mx="auto" maxW="210px" src={btcJsonFile} />
         <BodySm textAlign="center">
           Read more about the&nbsp;
-          <ViewInBlockExplorer
-            id={bridgeContractAddress}
-            type={ExplorerDataType.ADDRESS}
-            text="bridge contract"
-          />
+          <Link isExternal href={ExternalHref.tbtcBridgeGithub}>
+            bridge contract
+          </Link>
           .
         </BodySm>
       </ModalBody>

--- a/src/components/Modal/tBTC/GenerateNewDepositAddress.tsx
+++ b/src/components/Modal/tBTC/GenerateNewDepositAddress.tsx
@@ -1,0 +1,82 @@
+import { FC } from "react"
+import {
+  Button,
+  Divider,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  BodyLg,
+  H5,
+  BodySm,
+  Image,
+} from "@threshold-network/components"
+import withBaseModal from "../withBaseModal"
+import tbtcIllustration from "../../../static/images/minting-step-2.svg"
+import { BaseModalProps } from "../../../types"
+import InfoBox from "../../InfoBox"
+import Link from "../../Link"
+import { ExternalHref } from "../../../enums"
+import ModalCloseButton from "../ModalCloseButton"
+import { useTBTCDepositDataFromLocalStorage } from "../../../hooks/tbtc"
+import { useTbtcState } from "../../../hooks/useTbtcState"
+
+const GenerateNewDepositAddressBase: FC<BaseModalProps> = ({ closeModal }) => {
+  const { removeDepositDataFromLocalStorage } =
+    useTBTCDepositDataFromLocalStorage()
+
+  const { resetDepositData } = useTbtcState()
+
+  const onConfirmClick = () => {
+    removeDepositDataFromLocalStorage()
+    resetDepositData()
+    closeModal()
+  }
+
+  return (
+    <>
+      <ModalHeader>Take note</ModalHeader>
+      <ModalCloseButton />
+      <ModalBody>
+        <InfoBox mt="0" variant="modal">
+          <H5 mb="3" color="gray.800">
+            You are about to go generate a new Deposit Address, are you sure?
+          </H5>
+          <BodyLg mb="12">
+            Going back means you will redo Step 1 and generate a new Deposit
+            Address.
+          </BodyLg>
+          <BodyLg>
+            You will not be able to use your current generated address if you
+            generate a new one.
+          </BodyLg>
+        </InfoBox>
+        <Image
+          src={tbtcIllustration}
+          maxH={{ base: "140px", xl: "unset" }}
+          maxW="200px"
+          mx="auto"
+          mt="12"
+          mb="14"
+        />
+        <BodySm textAlign="center" color="gray.500">
+          Read more about the&nbsp;
+          <Link isExternal href={ExternalHref.tbtcBridgeGithub}>
+            bridge contract
+          </Link>
+          .
+        </BodySm>
+        <Divider mt="2" />
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={onConfirmClick} variant="outline" mr="3">
+          Generate New Address
+        </Button>
+        <Button onClick={closeModal}>Dismiss</Button>
+      </ModalFooter>
+    </>
+  )
+}
+
+export const GenerateNewDepositAddress = withBaseModal(
+  GenerateNewDepositAddressBase
+)

--- a/src/components/Modal/tBTC/NewTBTCApp.tsx
+++ b/src/components/Modal/tBTC/NewTBTCApp.tsx
@@ -24,7 +24,6 @@ const NewTBTCAppBase: FC<BaseModalProps> = ({ closeModal }) => {
   return (
     <>
       <ModalHeader>Take note</ModalHeader>
-      <ModalCloseButton />
       <ModalBody>
         <Image
           src={tbtcAppBannerIllustration}

--- a/src/components/Modal/tBTC/NewTBTCApp.tsx
+++ b/src/components/Modal/tBTC/NewTBTCApp.tsx
@@ -11,7 +11,6 @@ import {
   Flex,
   Image,
 } from "@threshold-network/components"
-import ModalCloseButton from "../ModalCloseButton"
 import { TakeNoteList } from "../../tBTC"
 import withBaseModal from "../withBaseModal"
 import tbtcAppBannerIllustration from "../../../static/images/tBTCAppBannerWithGrid.svg"

--- a/src/components/Modal/tBTC/index.ts
+++ b/src/components/Modal/tBTC/index.ts
@@ -1,1 +1,2 @@
 export * from "./NewTBTCApp"
+export * from "./GenerateNewDepositAddress"

--- a/src/enums/modal.ts
+++ b/src/enums/modal.ts
@@ -37,4 +37,5 @@ export enum ModalType {
   Analytics = "ANALYTICS",
   NewTBTCApp = "NEW_TBTC_APP",
   FeedbackSubmission = "FEEDBACK_SUBMIT",
+  GenerateNewDepositAddress = "TBTC_GENERATE_NEW_DEPOSIT_ADDRESS",
 }

--- a/src/hooks/useTbtcState.ts
+++ b/src/hooks/useTbtcState.ts
@@ -1,17 +1,32 @@
-import { useDispatch, useSelector } from "react-redux"
+import { useCallback } from "react"
 import { RootState } from "../store"
-import { TbtcStateKey, UseTbtcState } from "../types/tbtc"
 import { updateState as updateStateAction } from "../store/tbtc"
+import { useAppDispatch, useAppSelector } from "./store"
+import { MintingStep, TbtcStateKey, UseTbtcState } from "../types/tbtc"
 
 export const useTbtcState: UseTbtcState = () => {
-  const tbtcState = useSelector((state: RootState) => state.tbtc)
-  const dispatch = useDispatch()
+  const tbtcState = useAppSelector((state: RootState) => state.tbtc)
+  const dispatch = useAppDispatch()
 
-  const updateState = (key: TbtcStateKey, value: any) =>
-    dispatch(updateStateAction({ key, value }))
+  const updateState = useCallback(
+    (key: TbtcStateKey, value: any) =>
+      dispatch(updateStateAction({ key, value })),
+    [dispatch]
+  )
+
+  const resetDepositData = useCallback(() => {
+    updateState("ethAddress", undefined)
+    updateState("blindingFactor", undefined)
+    updateState("btcRecoveryAddress", undefined)
+    updateState("walletPublicKeyHash", undefined)
+    updateState("refundLocktime", undefined)
+    updateState("btcDepositAddress", undefined)
+    updateState("mintingStep", MintingStep.ProvideData)
+  }, [dispatch, updateState])
 
   return {
     ...tbtcState,
     updateState,
+    resetDepositData,
   }
 }

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -1,28 +1,30 @@
-import { Container, Image } from "@chakra-ui/react"
+import { H1, Container, Image } from "@threshold-network/components"
 import { Outlet } from "react-router-dom"
 import thresholdWordMark from "../../static/images/thresholdWordMark.svg"
-import { H1 } from "@threshold-network/components"
 import useDocumentTitle from "../../hooks/useDocumentTitle"
 import Network from "./Network"
 import { PageComponent } from "../../types"
-import { AuthorizeApplicationsBanner } from "./AuthorizeApplicationsBanner"
 import { featureFlags } from "../../constants"
-import AnalyticsBanner from "./AnalyticsBanner"
-import { useAnalytics } from "../../hooks/useAnalytics"
+import AnnouncementBanner from "../../components/AnnouncementBanner"
+import tbtcAppBannerIllustration from "../../static/images/tBTCAppBanner.svg"
 
 const Overview: PageComponent = () => {
   useDocumentTitle("Threshold - Overview")
-
-  const { isAnalyticsEnabled, hasUserResponded } = useAnalytics()
 
   return (
     <Container maxW={{ base: "2xl", xl: "6xl" }} my={16}>
       <Image src={thresholdWordMark} mb={4} />
       <H1 mb={12}>Overview</H1>
-      {featureFlags.FEEDBACK_MODULE &&
-        !isAnalyticsEnabled &&
-        !hasUserResponded && <AnalyticsBanner />}
-      {featureFlags.MULTI_APP_STAKING && <AuthorizeApplicationsBanner />}
+      {featureFlags.TBTC_V2 && (
+        <AnnouncementBanner
+          variant="primary"
+          imgSrc={tbtcAppBannerIllustration}
+          preTitle="get started"
+          title="The NEW tBTC dApp is here!"
+          href="/tBTC"
+          buttonText="Start Minting"
+        />
+      )}
       <Outlet />
     </Container>
   )

--- a/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
@@ -87,7 +87,15 @@ const MakeDepositComponent: FC = () => {
         provided.
       </BodyMd>
       <InfoBox>
-        <HStack>
+        <HStack
+          alignItems="center"
+          // To center the tooltip icon. The tooltip icon is wrapped by `span`
+          // because of: If you're wrapping an icon from `react-icons`, you need
+          // to also wrap the icon in a `span` element as `react-icons` icons do
+          // not use forwardRef. See
+          // https://chakra-ui.com/docs/components/tooltip#with-an-icon.
+          sx={{ ">span": { display: "flex" } }}
+        >
           <BodyMd color="gray.700">BTC Deposit Address</BodyMd>
           <TooltipIcon label="This is an unique BTC address generated based on the ETH address and Recovery address you provided. Send your BTC funds to this address in order to mint tBTC." />
         </HStack>
@@ -112,7 +120,15 @@ const MakeDepositComponent: FC = () => {
           />
         </Box>
 
-        <HStack bg="white" borderRadius="lg" justify="center" mb="5" p="1">
+        <HStack
+          bg="white"
+          borderRadius="lg"
+          justify="center"
+          mb="2"
+          p="1"
+          pl="2"
+          sx={{ ">div": { marginInlineStart: "0 !important" } }}
+        >
           <BodyMd color="brand.500" isTruncated>
             {btcDepositAddress}
           </BodyMd>

--- a/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
@@ -86,7 +86,7 @@ const MakeDepositComponent: FC = () => {
         This address is an unique generated address based on the data you
         provided.
       </BodyMd>
-      <InfoBox>
+      <InfoBox p="4">
         <HStack
           alignItems="center"
           // To center the tooltip icon. The tooltip icon is wrapped by `span`

--- a/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
@@ -22,6 +22,8 @@ import { QRCode } from "../../../../components/QRCode"
 import { useThreshold } from "../../../../contexts/ThresholdContext"
 import { UnspentTransactionOutput } from "@keep-network/tbtc-v2.ts/dist/bitcoin"
 import withOnlyConnectedWallet from "../../../../components/withOnlyConnectedWallet"
+import { useModal } from "../../../../hooks/useModal"
+import { ModalType } from "../../../../enums"
 
 const AddressRow: FC<{ address: string; text: string }> = ({
   address,
@@ -39,6 +41,7 @@ const AddressRow: FC<{ address: string; text: string }> = ({
 }
 
 const MakeDepositComponent: FC = () => {
+  const { openModal } = useModal()
   const { btcDepositAddress, ethAddress, btcRecoveryAddress, updateState } =
     useTbtcState()
   const threshold = useThreshold()
@@ -71,9 +74,16 @@ const MakeDepositComponent: FC = () => {
     }
   }
 
+  const onPreviousStepClick = () => {
+    openModal(ModalType.GenerateNewDepositAddress)
+  }
+
   return (
     <>
-      <TbtcMintingCardTitle previousStep={MintingStep.ProvideData} />
+      <TbtcMintingCardTitle
+        previousStep={MintingStep.ProvideData}
+        onPreviousStepClick={onPreviousStepClick}
+      />
       <TbtcMintingCardSubTitle
         stepText="Step 2"
         subTitle="Make your BTC deposit"

--- a/src/pages/tBTC/Bridge/MintingCard/MintingTimeline.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingTimeline.tsx
@@ -7,6 +7,8 @@ import tbtcMintingStep2 from "../../../../static/images/minting-step-2.svg"
 import tbtcMintingStep3 from "../../../../static/images/minting-step-3.svg"
 import { useTbtcState } from "../../../../hooks/useTbtcState"
 import { MintingStep } from "../../../../types/tbtc"
+import Link from "../../../../components/Link"
+import { ExternalHref } from "../../../../enums"
 
 type MintingTimelineStepProps = Omit<
   TimelineProps,
@@ -25,7 +27,16 @@ export const MintingTimelineStep1: FC<MintingTimelineStepProps> = ({
       stepText="Step 1"
       helperLabelText="OFF-CHAIN ACTION"
       title="Provide Data"
-      description="Provide an ETH address and a BTC Recovery address to generate an unique BTC deposit address."
+      description={
+        <>
+          Provide an ETH address and a BTC Recovery address to generate an
+          unique BTC deposit address. {/* TODO: set correct link here */}
+          <Link isExternal href={ExternalHref.btcRecoveryAddress}>
+            Read more
+          </Link>
+          .
+        </>
+      }
       imageSrc={tbtcMintingStep1}
       {...restProps}
     />

--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -43,7 +43,7 @@ const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
       <FormikInput
         name="btcRecoveryAddress"
         label="BTC Recovery Address"
-        tooltip="Recovery Address is a BTC address where your BTC funds are sent back if something exceptional happens with your deposit. The funds can be claimed."
+        tooltip="Recovery Address is a BTC address where your BTC funds are sent back if something exceptional happens with your deposit. The funds can be claimed by using the JSON file."
       />
     </Form>
   )
@@ -139,7 +139,7 @@ export const ProvideDataComponent: FC = () => {
       <TbtcMintingCardSubTitle stepText="Step 1" subTitle="Provide Data" />
       <BodyMd color="gray.500" mb={12}>
         Based on these two addresses, the system will generate for you an unique
-        BTC deposit address. There is no minting limit
+        BTC deposit address. There is no minting limit.
       </BodyMd>
       <MintingProcessForm
         innerRef={formRef}

--- a/src/pages/tBTC/Bridge/components/TbtcMintingCardTitle.tsx
+++ b/src/pages/tBTC/Bridge/components/TbtcMintingCardTitle.tsx
@@ -5,27 +5,14 @@ import { LabelSm } from "@threshold-network/components"
 import { tBTCFillBlack } from "../../../../static/icons/tBTCFillBlack"
 import { useTbtcState } from "../../../../hooks/useTbtcState"
 import { MintingStep, TbtcMintingType } from "../../../../types/tbtc"
-import { useTBTCDepositDataFromLocalStorage } from "../../../../hooks/tbtc"
 
-export const TbtcMintingCardTitle: FC<{ previousStep?: MintingStep }> = ({
-  previousStep,
-}) => {
+export const TbtcMintingCardTitle: FC<{
+  previousStep?: MintingStep
+  onPreviousStepClick?: () => void
+}> = ({ previousStep, onPreviousStepClick }) => {
   const { mintingType, updateState } = useTbtcState()
-  const { removeDepositDataFromLocalStorage } =
-    useTBTCDepositDataFromLocalStorage()
 
-  const onPreviousStepClick = (previousStep?: MintingStep) => {
-    if (previousStep === MintingStep.ProvideData) {
-      removeDepositDataFromLocalStorage()
-
-      // remove deposit data from the state,
-      updateState("ethAddress", undefined)
-      updateState("blindingFactor", undefined)
-      updateState("btcRecoveryAddress", undefined)
-      updateState("walletPublicKeyHash", undefined)
-      updateState("refundLocktime", undefined)
-      updateState("btcDepositAddress", undefined)
-    }
+  const defaultOnPreviousStepClick = () => {
     updateState("mintingStep", previousStep)
   }
 
@@ -34,7 +21,7 @@ export const TbtcMintingCardTitle: FC<{ previousStep?: MintingStep }> = ({
       {previousStep && (
         <Icon
           cursor="pointer"
-          onClick={() => onPreviousStepClick(previousStep)}
+          onClick={onPreviousStepClick ?? defaultOnPreviousStepClick}
           mt="4px"
           as={HiArrowNarrowLeft}
         />

--- a/src/pages/tBTC/Bridge/components/TimelineItem.tsx
+++ b/src/pages/tBTC/Bridge/components/TimelineItem.tsx
@@ -22,7 +22,7 @@ export type TimelineProps = {
   isActive: boolean
   isComplete: boolean
   title: string
-  description: string
+  description: string | JSX.Element
   imageSrc: any
   size?: Sizes
   withBadge?: boolean

--- a/src/pages/tBTC/Bridge/components/TransactionDetailsTable.tsx
+++ b/src/pages/tBTC/Bridge/components/TransactionDetailsTable.tsx
@@ -38,10 +38,6 @@ const TransactionDetailsTable = () => {
         <BodySm color="gray.700">{thresholdNetworkFee} BTC</BodySm>
       </HStack>
       <HStack justifyContent="space-between">
-        <BodySm color="gray.500">tBTC</BodySm>
-        <BodySm color="gray.700">1 BTC</BodySm>
-      </HStack>
-      <HStack justifyContent="space-between">
         <BodySm color="gray.500">ETH address</BodySm>
         <BodySm color="gray.700">{shortenAddress(ethAddress)}</BodySm>
       </HStack>

--- a/src/theme/InfoBox.ts
+++ b/src/theme/InfoBox.ts
@@ -6,14 +6,13 @@ export const InfoBox = {
   },
   baseStyle: {
     mt: 4,
-    p: 4,
+    p: 6,
     borderRadius: "md",
     mb: 2,
   },
   variants: {
     modal: (props: any) => ({
       background: mode("gray.50", "gray.800")(props),
-      padding: 4,
       marginTop: 0,
     }),
     base: (props: any) => ({

--- a/src/theme/InfoBox.ts
+++ b/src/theme/InfoBox.ts
@@ -6,8 +6,7 @@ export const InfoBox = {
   },
   baseStyle: {
     mt: 4,
-    px: 6,
-    py: 2,
+    p: 4,
     borderRadius: "md",
     mb: 2,
   },

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -45,7 +45,7 @@ import MapOperatorToStakingProviderModal from "../components/Modal/MapOperatorTo
 import MapOperatorToStakingProviderConfirmationModal from "../components/Modal/MapOperatorToStakingProviderConfirmationModal"
 import { MapOperatorToStakingProviderSuccess } from "../components/Modal/MapOperatorToStakingProviderSuccessModal"
 import AnalyticsModal from "../components/Modal/AnalyticsModal"
-import { NewTBTCApp } from "../components/Modal/tBTC"
+import { GenerateNewDepositAddress, NewTBTCApp } from "../components/Modal/tBTC"
 import FeedbackSubmissionModal from "../components/Modal/FeedbackSubmissionModal"
 
 export const MODAL_TYPES: Record<ModalType, ElementType> = {
@@ -92,6 +92,7 @@ export const MODAL_TYPES: Record<ModalType, ElementType> = {
   [ModalType.Analytics]: AnalyticsModal,
   [ModalType.NewTBTCApp]: NewTBTCApp,
   [ModalType.FeedbackSubmission]: FeedbackSubmissionModal,
+  [ModalType.GenerateNewDepositAddress]: GenerateNewDepositAddress,
 }
 
 export interface BaseModalProps {

--- a/src/types/tbtc.ts
+++ b/src/types/tbtc.ts
@@ -76,6 +76,7 @@ export interface UseTbtcState {
     thresholdNetworkFee: number
     bitcoinMinerFee: number
     isLoadingBitcoinMinerFee: boolean
+    resetDepositData: () => void
   }
 }
 


### PR DESCRIPTION
Depends on: #321 

This PR fixes UI bugs based on the [feedback from QA](https://coda.io/d/Building-Keep_d-fmEgBNFVH/2023-01-11-QA-tBTC-v2_subq6#_luufw). Besides, it adds a new modal to the tBTC deposit form- this modal should be displayed when the user clicks `back` button in Step 2 of the deposit form. This modal asks users if they want to generate a new deposit address and informs them about the consequences. If a user confirms generating a new deposit address, they will be redirected to Step 1 and the deposit data will be removed from local storage. If a user closes this modal it means they want to use already generated deposit address.