### PR TITLE
WSS connection workaround for Electrum client

### DIFF
--- a/src/threshold-ts/tbtc/index.ts
+++ b/src/threshold-ts/tbtc/index.ts
@@ -193,7 +193,11 @@ export class TBTC implements ITBTC {
       ethereumConfig.account
     )
     this._bitcoinClient =
-      bitcoinConfig.client ?? new ElectrumClient(bitcoinConfig.credentials!)
+      bitcoinConfig.client ??
+      new ElectrumClient(
+        bitcoinConfig.credentials!,
+        bitcoinConfig.clientOptions
+      )
     this._multicall = multicall
     this._bitcoinConfig = bitcoinConfig
   }

--- a/src/threshold-ts/types/index.ts
+++ b/src/threshold-ts/types/index.ts
@@ -1,5 +1,8 @@
 import { Client } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
-import { Credentials } from "@keep-network/tbtc-v2.ts/dist/src/electrum"
+import {
+  ClientOptions,
+  Credentials,
+} from "@keep-network/tbtc-v2.ts/dist/src/electrum"
 import { providers, Signer } from "ethers"
 
 export enum BitcoinNetwork {
@@ -15,7 +18,7 @@ export interface EthereumConfig {
 
 export type BitcoinClientCredentials = Credentials
 
-export type BitcoinClientOptions = object
+export type BitcoinClientOptions = ClientOptions
 
 export interface BitcoinConfig {
   /**

--- a/src/threshold-ts/types/index.ts
+++ b/src/threshold-ts/types/index.ts
@@ -15,7 +15,7 @@ export interface EthereumConfig {
 
 export type BitcoinClientCredentials = Credentials
 
-export type BitcoinClientConfig = object
+export type BitcoinClientOptions = object
 
 export interface BitcoinConfig {
   /**
@@ -38,7 +38,7 @@ export interface BitcoinConfig {
   /**
    * Additional options that can be passed to bitcoin client
    */
-  clientOptions?: BitcoinClientConfig
+  clientOptions?: BitcoinClientOptions
 }
 
 export interface ThresholdConfig {

--- a/src/threshold-ts/types/index.ts
+++ b/src/threshold-ts/types/index.ts
@@ -15,6 +15,8 @@ export interface EthereumConfig {
 
 export type BitcoinClientCredentials = Credentials
 
+export type BitcoinClientConfig = object
+
 export interface BitcoinConfig {
   /**
    * Indicates for which network the addresses (eg deposit address) should be
@@ -32,6 +34,11 @@ export interface BitcoinConfig {
    * Credentials for electrum client
    */
   credentials?: BitcoinClientCredentials
+
+  /**
+   * Additional options that can be passed to bitcoin client
+   */
+  clientOptions?: BitcoinClientConfig
 }
 
 export interface ThresholdConfig {

--- a/src/utils/getThresholdLib.ts
+++ b/src/utils/getThresholdLib.ts
@@ -31,8 +31,9 @@ function getBitcoinConfig(): BitcoinConfig {
     client: shouldMockBitcoinClient ? new MockBitcoinClient() : undefined,
     network,
     credentials: !shouldMockBitcoinClient ? credentials : undefined,
-    // FIXME: It's a temporary workaround to get the connection working.
-    clientOptions: { rejectUnauthorize: false },
+    // FIXME: It's a temporary workaround to get the wss connection working.
+    clientOptions:
+      credentials.protocol === "wss" ? { rejectUnauthorize: false } : undefined,
   }
 }
 

--- a/src/utils/getThresholdLib.ts
+++ b/src/utils/getThresholdLib.ts
@@ -31,6 +31,8 @@ function getBitcoinConfig(): BitcoinConfig {
     client: shouldMockBitcoinClient ? new MockBitcoinClient() : undefined,
     network,
     credentials: !shouldMockBitcoinClient ? credentials : undefined,
+    // FIXME: It's a temporary workaround to get the connection working.
+    clientOptions: { rejectUnauthorize: false },
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3423,7 +3423,7 @@
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
     "@threshold-network/solidity-contracts" ">1.1.0-dev <1.1.0-ropsten"
 
-"@keep-network/ecdsa@2.1.0-dev.6":
+"@keep-network/ecdsa@2.1.0-dev.6", "@keep-network/ecdsa@development":
   version "2.1.0-dev.6"
   resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.1.0-dev.6.tgz#ccc690f784b6e802a5b80b2dfb7127d96e548a25"
   integrity sha512-1D74OPVzzxxVcG8za/niuxmwEdDc5R6KNuHsUvsFkcHNJE1UgQNw+QdrI+k3M2so6YrO4L5lP7vTvIvBDbEMNQ==
@@ -3444,17 +3444,6 @@
     "@openzeppelin/contracts" "^4.6.0"
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
     "@threshold-network/solidity-contracts" "1.3.0-dev.2"
-
-"@keep-network/ecdsa@development":
-  version "2.1.0-dev.6"
-  resolved "https://registry.npmjs.org/@keep-network/ecdsa/-/ecdsa-2.1.0-dev.6.tgz#ccc690f784b6e802a5b80b2dfb7127d96e548a25"
-  integrity sha512-1D74OPVzzxxVcG8za/niuxmwEdDc5R6KNuHsUvsFkcHNJE1UgQNw+QdrI+k3M2so6YrO4L5lP7vTvIvBDbEMNQ==
-  dependencies:
-    "@keep-network/random-beacon" "2.1.0-dev.5"
-    "@keep-network/sortition-pools" "^2.0.0-pre.16"
-    "@openzeppelin/contracts" "^4.6.0"
-    "@openzeppelin/contracts-upgradeable" "^4.6.0"
-    "@threshold-network/solidity-contracts" "1.3.0-dev.3"
 
 "@keep-network/keep-core@1.8.0-dev.5":
   version "1.8.0-dev.5"
@@ -3552,9 +3541,9 @@
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/tbtc-v2.ts@development":
-  version "1.0.0-dev.23"
-  resolved "https://registry.npmjs.org/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.0.0-dev.23.tgz#18f2168344be6b6924f807359e1a3377a3a0edce"
-  integrity sha512-AOmNTRPLzgHJ7rKKFdvtytqZ6btjNX1sctb6sNgtfv+2XFLse8Rwgoh0yl4s9nSUNKlv4aVSLWA5pWkbkUJeOw==
+  version "1.0.0-dev.24"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.0.0-dev.24.tgz#2ae84528a1f48fa4a8ed7367533c626f98fa4f61"
+  integrity sha512-S99/wjf86Km0RRwmXWMavmOy9KJNsZbAqgRAJOQyyGZSiUWTNSrlGp6UO4n1OJMtIODSV3gmr6+06GxH77EnvA==
   dependencies:
     "@keep-network/ecdsa" development
     "@keep-network/tbtc-v2" "1.0.1-dev.1"
@@ -8716,9 +8705,16 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4
     node-releases "^2.0.5"
     update-browserslist-db "^1.0.4"
 
-"brq@git+https://github.com/bcoin-org/brq.git#semver:~0.1.7", brq@~0.1.7, brq@~0.1.8:
+"brq@git+https://github.com/bcoin-org/brq.git#semver:~0.1.7":
   version "0.1.8"
   resolved "git+https://github.com/bcoin-org/brq.git#534bb2c83fb366ba40ad80bc3de796a174503294"
+  dependencies:
+    bsert "~0.0.10"
+
+brq@~0.1.7, brq@~0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/brq/-/brq-0.1.8.tgz#35c68bf48e0aef19e397dcd1a1ba7a0cfb3baca2"
+  integrity sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==
   dependencies:
     bsert "~0.0.10"
 
@@ -8762,19 +8758,12 @@ bser@2.1.1:
 
 bsert@~0.0.10:
   version "0.0.10"
-  resolved "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz#231ac82873a1418c6ade301ab5cd9ae385895597"
+  resolved "https://registry.yarnpkg.com/bsert/-/bsert-0.0.10.tgz#231ac82873a1418c6ade301ab5cd9ae385895597"
   integrity sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==
 
-"bsock@git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9":
+"bsock@git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9", bsock@~0.1.8, bsock@~0.1.9:
   version "0.1.9"
   resolved "git+https://github.com/bcoin-org/bsock.git#7cf76b3021ae7929c023d1170f789811e91ae528"
-  dependencies:
-    bsert "~0.0.10"
-
-bsock@~0.1.8, bsock@~0.1.9:
-  version "0.1.9"
-  resolved "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz#6aa14b8e4bda730e0f60ec73eb52a8a888ac22c8"
-  integrity sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==
   dependencies:
     bsert "~0.0.10"
 
@@ -8887,7 +8876,7 @@ bufferutil@^4.0.1:
 
 bufio@^1.0.6:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/bufio/-/bufio-1.2.0.tgz#b9ad1c06b0d9010363c387c39d2810a7086d143f"
+  resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.2.0.tgz#b9ad1c06b0d9010363c387c39d2810a7086d143f"
   integrity sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA==
 
 "bufio@git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6":
@@ -8896,7 +8885,7 @@ bufio@^1.0.6:
 
 bufio@~1.0.7:
   version "1.0.7"
-  resolved "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz#b7f63a1369a0829ed64cc14edf0573b3e382a33e"
+  resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.0.7.tgz#b7f63a1369a0829ed64cc14edf0573b3e382a33e"
   integrity sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==
 
 builtin-modules@^3.1.0:
@@ -16323,14 +16312,9 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1":
+"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1", loady@~0.0.1, loady@~0.0.5:
   version "0.0.5"
   resolved "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
-
-loady@~0.0.1, loady@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz#b17adb52d2fb7e743f107b0928ba0b591da5d881"
-  integrity sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==
 
 locate-path@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8705,16 +8705,9 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4
     node-releases "^2.0.5"
     update-browserslist-db "^1.0.4"
 
-"brq@git+https://github.com/bcoin-org/brq.git#semver:~0.1.7":
+"brq@git+https://github.com/bcoin-org/brq.git#semver:~0.1.7", brq@~0.1.7, brq@~0.1.8:
   version "0.1.8"
   resolved "git+https://github.com/bcoin-org/brq.git#534bb2c83fb366ba40ad80bc3de796a174503294"
-  dependencies:
-    bsert "~0.0.10"
-
-brq@~0.1.7, brq@~0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/brq/-/brq-0.1.8.tgz#35c68bf48e0aef19e397dcd1a1ba7a0cfb3baca2"
-  integrity sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==
   dependencies:
     bsert "~0.0.10"
 
@@ -8761,9 +8754,16 @@ bsert@~0.0.10:
   resolved "https://registry.yarnpkg.com/bsert/-/bsert-0.0.10.tgz#231ac82873a1418c6ade301ab5cd9ae385895597"
   integrity sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==
 
-"bsock@git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9", bsock@~0.1.8, bsock@~0.1.9:
+"bsock@git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9":
   version "0.1.9"
   resolved "git+https://github.com/bcoin-org/bsock.git#7cf76b3021ae7929c023d1170f789811e91ae528"
+  dependencies:
+    bsert "~0.0.10"
+
+bsock@~0.1.8, bsock@~0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/bsock/-/bsock-0.1.9.tgz#6aa14b8e4bda730e0f60ec73eb52a8a888ac22c8"
+  integrity sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==
   dependencies:
     bsert "~0.0.10"
 
@@ -16312,9 +16312,14 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1", loady@~0.0.1, loady@~0.0.5:
+"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1":
   version "0.0.5"
   resolved "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
+
+loady@~0.0.1, loady@~0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/loady/-/loady-0.0.5.tgz#b17adb52d2fb7e743f107b0928ba0b591da5d881"
+  integrity sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==
 
 locate-path@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,9 +3541,9 @@
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/tbtc-v2.ts@development":
-  version "1.0.0-dev.24"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.0.0-dev.24.tgz#2ae84528a1f48fa4a8ed7367533c626f98fa4f61"
-  integrity sha512-S99/wjf86Km0RRwmXWMavmOy9KJNsZbAqgRAJOQyyGZSiUWTNSrlGp6UO4n1OJMtIODSV3gmr6+06GxH77EnvA==
+  version "1.0.0-dev.25"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.0.0-dev.25.tgz#f5d2cba613283310e200806139c1a220535fc469"
+  integrity sha512-6pLFZjcAPRzmnhoHNpfds7LxaSl55v/MuaYgW/IHB96cOXSmfh1U9JTNpub31FDzuDvTZ7t9TggPWYSM+DMwkQ==
   dependencies:
     "@keep-network/ecdsa" development
     "@keep-network/tbtc-v2" "1.0.1-dev.1"
@@ -8754,16 +8754,9 @@ bsert@~0.0.10:
   resolved "https://registry.yarnpkg.com/bsert/-/bsert-0.0.10.tgz#231ac82873a1418c6ade301ab5cd9ae385895597"
   integrity sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==
 
-"bsock@git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9":
+"bsock@git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9", bsock@~0.1.8, bsock@~0.1.9:
   version "0.1.9"
   resolved "git+https://github.com/bcoin-org/bsock.git#7cf76b3021ae7929c023d1170f789811e91ae528"
-  dependencies:
-    bsert "~0.0.10"
-
-bsock@~0.1.8, bsock@~0.1.9:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/bsock/-/bsock-0.1.9.tgz#6aa14b8e4bda730e0f60ec73eb52a8a888ac22c8"
-  integrity sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==
   dependencies:
     bsert "~0.0.10"
 


### PR DESCRIPTION
Electrum client does not work properly with WSS connection. As a workaround we will pass the `options` object to the client with `rejectUnauthorized` flag set to `false`