### PR TITLE
Remove `rejectUnauthorized` option passed to Electrum client

### DIFF
--- a/src/utils/getThresholdLib.ts
+++ b/src/utils/getThresholdLib.ts
@@ -31,11 +31,6 @@ function getBitcoinConfig(): BitcoinConfig {
     client: shouldMockBitcoinClient ? new MockBitcoinClient() : undefined,
     network,
     credentials: !shouldMockBitcoinClient ? credentials : undefined,
-    // FIXME: It's a temporary workaround to get the wss connection working.
-    clientOptions:
-      credentials.protocol === "wss"
-        ? { rejectUnauthorized: false }
-        : undefined,
   }
 }
 

--- a/src/utils/getThresholdLib.ts
+++ b/src/utils/getThresholdLib.ts
@@ -33,7 +33,9 @@ function getBitcoinConfig(): BitcoinConfig {
     credentials: !shouldMockBitcoinClient ? credentials : undefined,
     // FIXME: It's a temporary workaround to get the wss connection working.
     clientOptions:
-      credentials.protocol === "wss" ? { rejectUnauthorize: false } : undefined,
+      credentials.protocol === "wss"
+        ? { rejectUnauthorized: false }
+        : undefined,
   }
 }
 

--- a/src/utils/getThresholdLib.ts
+++ b/src/utils/getThresholdLib.ts
@@ -44,12 +44,15 @@ export const getDefaultThresholdLibProvider = () => {
 }
 
 export const getThresholdLib = (providerOrSigner?: Provider | Signer) => {
+  const bitcoinConfig = getBitcoinConfig()
+  // TODO: this is only for testing purposes, remove this later
+  console.log("bitcoinConfig", bitcoinConfig)
   return new Threshold({
     ethereum: {
       chainId: supportedChainId,
       providerOrSigner: providerOrSigner || getDefaultThresholdLibProvider(),
     },
-    bitcoin: getBitcoinConfig(),
+    bitcoin: bitcoinConfig,
   })
 }
 

--- a/src/utils/getThresholdLib.ts
+++ b/src/utils/getThresholdLib.ts
@@ -39,15 +39,12 @@ export const getDefaultThresholdLibProvider = () => {
 }
 
 export const getThresholdLib = (providerOrSigner?: Provider | Signer) => {
-  const bitcoinConfig = getBitcoinConfig()
-  // TODO: this is only for testing purposes, remove this later
-  console.log("bitcoinConfig", bitcoinConfig)
   return new Threshold({
     ethereum: {
       chainId: supportedChainId,
       providerOrSigner: providerOrSigner || getDefaultThresholdLibProvider(),
     },
-    bitcoin: bitcoinConfig,
+    bitcoin: getBitcoinConfig(),
   })
 }
 


### PR DESCRIPTION
Ref #355 

~There was a typo in options that we passed to tbtc-v2.ts lib for electrum client. Instead of `rejectUnauthorize` it should be `rejectUnauthorized`.~

Update:
The above solution did not work and it turns out the problem with wss connection was something else. It is resolved now so we are removing this options and won't pass it to the electrum client as it is not needed anymore.