### PR TITLE
Update tbtc-v2.ts lib to 1.0.0-dev.29

### DIFF
--- a/src/components/Modal/TbtcMintingConfirmationModal/index.tsx
+++ b/src/components/Modal/TbtcMintingConfirmationModal/index.tsx
@@ -30,7 +30,7 @@ import {
 } from "../../../hooks/tbtc"
 import { BigNumber } from "ethers"
 import { formatTokenAmount } from "../../../utils/formatAmount"
-import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
+import { getChainIdentifier } from "../../../threshold-ts/utils"
 
 export interface TbtcMintingConfirmationModalProps extends BaseModalProps {
   utxos: UnspentTransactionOutput[]
@@ -64,7 +64,7 @@ const TbtcMintingConfirmationModal: FC<TbtcMintingConfirmationModalProps> = ({
 
   const initiateMintTransaction = async () => {
     const depositScriptParameters: DepositScriptParameters = {
-      depositor: EthereumAddress.from(ethAddress),
+      depositor: getChainIdentifier(ethAddress),
       blindingFactor,
       walletPublicKeyHash: walletPublicKeyHash,
       refundPublicKeyHash: decodeBitcoinAddress(btcRecoveryAddress),

--- a/src/components/Modal/TbtcMintingConfirmationModal/index.tsx
+++ b/src/components/Modal/TbtcMintingConfirmationModal/index.tsx
@@ -20,7 +20,6 @@ import TransactionDetailsTable from "../../../pages/tBTC/Bridge/components/Trans
 import { MintingStep } from "../../../types/tbtc"
 import { useThreshold } from "../../../contexts/ThresholdContext"
 import { DepositScriptParameters } from "@keep-network/tbtc-v2.ts/dist/src/deposit"
-import { unprefixedAndUncheckedAddress } from "../../../web3/utils"
 import {
   decodeBitcoinAddress,
   UnspentTransactionOutput,
@@ -31,6 +30,7 @@ import {
 } from "../../../hooks/tbtc"
 import { BigNumber } from "ethers"
 import { formatTokenAmount } from "../../../utils/formatAmount"
+import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
 
 export interface TbtcMintingConfirmationModalProps extends BaseModalProps {
   utxos: UnspentTransactionOutput[]
@@ -64,9 +64,7 @@ const TbtcMintingConfirmationModal: FC<TbtcMintingConfirmationModalProps> = ({
 
   const initiateMintTransaction = async () => {
     const depositScriptParameters: DepositScriptParameters = {
-      depositor: {
-        identifierHex: unprefixedAndUncheckedAddress(ethAddress),
-      },
+      depositor: EthereumAddress.from(ethAddress),
       blindingFactor,
       walletPublicKeyHash: walletPublicKeyHash,
       refundPublicKeyHash: decodeBitcoinAddress(btcRecoveryAddress),

--- a/src/components/Modal/TbtcRecoveryFileModal/index.tsx
+++ b/src/components/Modal/TbtcRecoveryFileModal/index.tsx
@@ -20,17 +20,24 @@ import { MintingStep } from "../../../types/tbtc"
 import { downloadFile } from "../../../web3/utils"
 import Link from "../../Link"
 import { ExternalHref } from "../../../enums"
+import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
 
 const TbtcRecoveryFileModalModal: FC<
   BaseModalProps & {
-    depositScriptParameters: DepositScriptParameters
     ethAddress: string
+    blindingFactor: string
+    walletPublicKeyHash: string
+    refundPublicKeyHash: string
+    refundLocktime: string
     btcDepositAddress: string
   }
 > = ({
   closeModal,
-  depositScriptParameters,
   ethAddress,
+  blindingFactor,
+  walletPublicKeyHash,
+  refundPublicKeyHash,
+  refundLocktime,
   btcDepositAddress,
 }) => {
   const { isOpen: isOnConfirmStep, onOpen: setIsOnConfirmStep } =
@@ -40,6 +47,14 @@ const TbtcRecoveryFileModalModal: FC<
   const handleDoubleReject = () => {
     updateState("mintingStep", MintingStep.Deposit)
     closeModal()
+  }
+
+  const depositScriptParameters: DepositScriptParameters = {
+    depositor: EthereumAddress.from(ethAddress),
+    blindingFactor,
+    walletPublicKeyHash,
+    refundPublicKeyHash,
+    refundLocktime,
   }
 
   const handleDownloadClick = () => {

--- a/src/components/Modal/TbtcRecoveryFileModal/index.tsx
+++ b/src/components/Modal/TbtcRecoveryFileModal/index.tsx
@@ -20,7 +20,7 @@ import { MintingStep } from "../../../types/tbtc"
 import { downloadFile } from "../../../web3/utils"
 import Link from "../../Link"
 import { ExternalHref } from "../../../enums"
-import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
+import { getChainIdentifier } from "../../../threshold-ts/utils"
 
 const TbtcRecoveryFileModalModal: FC<
   BaseModalProps & {
@@ -50,7 +50,7 @@ const TbtcRecoveryFileModalModal: FC<
   }
 
   const depositScriptParameters: DepositScriptParameters = {
-    depositor: EthereumAddress.from(ethAddress),
+    depositor: getChainIdentifier(ethAddress),
     blindingFactor,
     walletPublicKeyHash,
     refundPublicKeyHash,

--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -129,9 +129,12 @@ export const ProvideDataComponent: FC<{
 
     // if the user has NOT declined the json file, ask the user if they want to accept the new file
     openModal(ModalType.TbtcRecoveryJson, {
-      depositScriptParameters,
-      btcDepositAddress: depositAddress,
       ethAddress: values.ethAddress,
+      blindingFactor: depositScriptParameters.blindingFactor,
+      walletPublicKeyHash: depositScriptParameters.walletPublicKeyHash,
+      refundPublicKeyHash: depositScriptParameters.refundPublicKeyHash,
+      refundLocktime: depositScriptParameters.refundLocktime,
+      btcDepositAddress: depositAddress,
     })
 
     // do not ask about JSON file again if the user has not changed anything because they have already accepted/declined the same json file

--- a/src/tbtc/mock-bitcoin-client.ts
+++ b/src/tbtc/mock-bitcoin-client.ts
@@ -1,4 +1,3 @@
-import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
 import {
   Client,
   decodeBitcoinAddress,
@@ -15,6 +14,7 @@ import {
   DepositScriptParameters,
 } from "@keep-network/tbtc-v2.ts/dist/src/deposit"
 import { BigNumber } from "ethers"
+import { getChainIdentifier } from "../threshold-ts/utils"
 import { delay } from "../utils/helpers"
 
 const testnetTransactionHash = TransactionHash.from(
@@ -116,7 +116,7 @@ export class MockBitcoinClient implements Client {
       } = tbtc
 
       const depositScriptParameters: DepositScriptParameters = {
-        depositor: EthereumAddress.from(ethAddress),
+        depositor: getChainIdentifier(ethAddress),
         blindingFactor: blindingFactor,
         walletPublicKeyHash: walletPublicKeyHash,
         refundPublicKeyHash: decodeBitcoinAddress(btcRecoveryAddress),

--- a/src/tbtc/mock-bitcoin-client.ts
+++ b/src/tbtc/mock-bitcoin-client.ts
@@ -1,3 +1,4 @@
+import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
 import {
   Client,
   decodeBitcoinAddress,
@@ -14,7 +15,6 @@ import {
   DepositScriptParameters,
 } from "@keep-network/tbtc-v2.ts/dist/src/deposit"
 import { BigNumber } from "ethers"
-import { unprefixedAndUncheckedAddress } from "../threshold-ts/utils"
 import { delay } from "../utils/helpers"
 
 const testnetTransactionHash = TransactionHash.from(
@@ -116,9 +116,7 @@ export class MockBitcoinClient implements Client {
       } = tbtc
 
       const depositScriptParameters: DepositScriptParameters = {
-        depositor: {
-          identifierHex: unprefixedAndUncheckedAddress(ethAddress),
-        },
+        depositor: EthereumAddress.from(ethAddress),
         blindingFactor: blindingFactor,
         walletPublicKeyHash: walletPublicKeyHash,
         refundPublicKeyHash: decodeBitcoinAddress(btcRecoveryAddress),

--- a/src/threshold-ts/tbtc/index.ts
+++ b/src/threshold-ts/tbtc/index.ts
@@ -13,6 +13,7 @@ import {
   getProviderOrSigner,
   isValidBtcAddress,
   getContractPastEvents,
+  getChainIdentifier,
 } from "../utils"
 import {
   Client,
@@ -23,7 +24,6 @@ import {
 } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
 import {
   ElectrumClient,
-  EthereumAddress,
   EthereumBridge,
 } from "@keep-network/tbtc-v2.ts/dist/src"
 import BridgeArtifact from "@keep-network/tbtc-v2/artifacts/Bridge.json"
@@ -241,7 +241,7 @@ export class TBTC implements ITBTC {
     )
 
     const depositScriptParameters: DepositScriptParameters = {
-      depositor: EthereumAddress.from(ethAddress),
+      depositor: getChainIdentifier(ethAddress),
       blindingFactor,
       walletPublicKeyHash,
       refundPublicKeyHash,
@@ -315,7 +315,7 @@ export class TBTC implements ITBTC {
       depositScriptParameters,
       this._bitcoinClient,
       this._bridge,
-      EthereumAddress.from(this._tbtcVault.address)
+      getChainIdentifier(this._tbtcVault.address)
     )
   }
 

--- a/src/threshold-ts/tbtc/index.ts
+++ b/src/threshold-ts/tbtc/index.ts
@@ -12,7 +12,6 @@ import {
   getContract,
   getProviderOrSigner,
   isValidBtcAddress,
-  unprefixedAndUncheckedAddress,
   getContractPastEvents,
 } from "../utils"
 import {
@@ -24,6 +23,7 @@ import {
 } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
 import {
   ElectrumClient,
+  EthereumAddress,
   EthereumBridge,
 } from "@keep-network/tbtc-v2.ts/dist/src"
 import BridgeArtifact from "@keep-network/tbtc-v2/artifacts/Bridge.json"
@@ -239,12 +239,9 @@ export class TBTC implements ITBTC {
       currentTimestamp,
       this._depositRefundLocktimDuration
     )
-    const identifierHex = unprefixedAndUncheckedAddress(ethAddress)
 
     const depositScriptParameters: DepositScriptParameters = {
-      depositor: {
-        identifierHex,
-      },
+      depositor: EthereumAddress.from(ethAddress),
       blindingFactor,
       walletPublicKeyHash,
       refundPublicKeyHash,
@@ -318,9 +315,7 @@ export class TBTC implements ITBTC {
       depositScriptParameters,
       this._bitcoinClient,
       this._bridge,
-      {
-        identifierHex: unprefixedAndUncheckedAddress(this._tbtcVault.address),
-      }
+      EthereumAddress.from(this._tbtcVault.address)
     )
   }
 

--- a/src/threshold-ts/utils/address.ts
+++ b/src/threshold-ts/utils/address.ts
@@ -3,6 +3,7 @@ import {
   getAddress as ethersGetAddress,
 } from "@ethersproject/address"
 import { AddressZero } from "@ethersproject/constants"
+import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
 
 export const unprefixedAndUncheckedAddress = (address: string): string => {
   const prefix = address.substring(0, 2)
@@ -27,3 +28,7 @@ export const isAddressZero = (address: string): boolean =>
   isSameETHAddress(address, AddressZero)
 
 export { AddressZero }
+
+export const getChainIdentifier = (ethAddress: string): EthereumAddress => {
+  return EthereumAddress.from(ethAddress)
+}

--- a/src/threshold-ts/utils/bitcoin.ts
+++ b/src/threshold-ts/utils/bitcoin.ts
@@ -1,3 +1,4 @@
+import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
 import { Network, validate } from "bitcoin-address-validation"
 
 export const isValidBtcAddress = (
@@ -5,4 +6,8 @@ export const isValidBtcAddress = (
   network: Network = Network.mainnet
 ): boolean => {
   return validate(address, network)
+}
+
+export const getChainIdentifier = (ethAddress: string): EthereumAddress => {
+  return EthereumAddress.from(ethAddress)
 }

--- a/src/threshold-ts/utils/bitcoin.ts
+++ b/src/threshold-ts/utils/bitcoin.ts
@@ -1,4 +1,3 @@
-import { EthereumAddress } from "@keep-network/tbtc-v2.ts"
 import { Network, validate } from "bitcoin-address-validation"
 
 export const isValidBtcAddress = (
@@ -6,8 +5,4 @@ export const isValidBtcAddress = (
   network: Network = Network.mainnet
 ): boolean => {
   return validate(address, network)
-}
-
-export const getChainIdentifier = (ethAddress: string): EthereumAddress => {
-  return EthereumAddress.from(ethAddress)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,12 +3541,12 @@
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/tbtc-v2.ts@development":
-  version "1.0.0-dev.25"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.0.0-dev.25.tgz#f5d2cba613283310e200806139c1a220535fc469"
-  integrity sha512-6pLFZjcAPRzmnhoHNpfds7LxaSl55v/MuaYgW/IHB96cOXSmfh1U9JTNpub31FDzuDvTZ7t9TggPWYSM+DMwkQ==
+  version "1.0.0-dev.29"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.0.0-dev.29.tgz#bb9d80edaf0bb15527196015ff604996ea87567d"
+  integrity sha512-Qf0ms4ASW80ejaougMPSEY1yt+IXqqzDtsAX38e6fTvTBcVg7XJTptmo6rp+FAjrZd3WXQLzYjObYLJMAO2YMA==
   dependencies:
     "@keep-network/ecdsa" development
-    "@keep-network/tbtc-v2" "1.0.1-dev.1"
+    "@keep-network/tbtc-v2" "1.0.3-dev.0"
     bcoin "git+https://github.com/keep-network/bcoin.git#5accd32c63e6025a0d35d67739c4a6e84095a1f8"
     bcrypto "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0"
     bufio "^1.0.6"
@@ -3554,7 +3554,20 @@
     ethers "^5.5.2"
     wif "2.0.6"
 
-"@keep-network/tbtc-v2@1.0.1-dev.1", "@keep-network/tbtc-v2@development":
+"@keep-network/tbtc-v2@1.0.3-dev.0":
+  version "1.0.3-dev.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.0.3-dev.0.tgz#754eab80269ea5a616c92cb8c1f607ec21343e0b"
+  integrity sha512-RqIFZvJtbLgmPZvPgamIJoTc5UsosrPE2g3879RqU4XqntezF4gr95FIuUFmicjRy0OPsjCupU2HplxlWfQfdw==
+  dependencies:
+    "@keep-network/bitcoin-spv-sol" "3.4.0-solc-0.8"
+    "@keep-network/ecdsa" "2.1.0-dev.6"
+    "@keep-network/random-beacon" "2.1.0-dev.5"
+    "@keep-network/tbtc" "1.1.2-dev.1"
+    "@openzeppelin/contracts" "^4.6.0"
+    "@openzeppelin/contracts-upgradeable" "^4.6.0"
+    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
+
+"@keep-network/tbtc-v2@development":
   version "1.0.1-dev.1"
   resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.0.1-dev.1.tgz#c5b661a386246915b33756cca6ae1f29d8c9a37e"
   integrity sha512-EbUEWu1RM76jjP5knpWDBvWxsdz1J94friT6sUJyhyVKKXNl/D6tw72Kj40+yq+To04pQNOZswROlhP8mfF5WQ==
@@ -8900,8 +8913,8 @@ builtin-status-codes@^3.0.0:
     bsert "~0.0.10"
 
 "bval@git+https://github.com/bcoin-org/bval.git#semver:~0.1.6":
-  version "0.1.6"
-  resolved "git+https://github.com/bcoin-org/bval.git#c8cd14419ca46f63610dc48b797b076835e86f48"
+  version "0.1.7"
+  resolved "git+https://github.com/bcoin-org/bval.git#5dcc923f24da9fb7eb96269ef8ce01540da983e7"
   dependencies:
     bsert "~0.0.10"
 


### PR DESCRIPTION
Update tbtc-v2.ts lib to `1.0.0-dev.29` version. This also requires to update all occurences of `Identifier` type in the dApp, because there was a change in tbtc-v2.ts lib that added `equals` function to the `Identifier`. The change was introduced here: https://github.com/keep-network/tbtc-v2/pull/460

The errors were fixed by creating the Identifier from the given ethereum address using `EthereumAddress.from(<eth_address>)`.

### Additional changes

#### Change the way we pass props to filerecovery modal

After the changes there was an error in the web console:

`A non-serializable value was detected in the state, in the path: modal.props.depositScriptParameters.depositor`.

It happens because when we open the modal we pass the parameters through the state and in this case we are opening `TbtcRecoveryFileModalModal`. A non-serializable value in this case is `equals` function that we passed with
`depositScriptParameters` property.

To fix that I've changed the way how we pass props to the modal - we pass each parameter on it's own instead of the whole `DepositScriptParameter` object as one property. So now instead of passing `Identifier` type we pass just an eth
address and we change it to `Identifier` inside the modal using `EthereumAddress.from(ethAddress)`.

#### Create `getChainIdentifier` util function

We use `EthereumAddress.from()` function in many places in the dApp. This is why I've introduced `getChainIdentifier` function that return the `Identifier` from it (or to be more technical, an `EthereumAddress` type that extends the
`Identifier` type). This might be helpful in the future if we change the way we calculate that identifier - we will only need to change the body of the `getChainIdentifier` function.