### PR TITLE
tBTCv2- token amount format improvements

### DIFF
--- a/src/components/Modal/TbtcMintingConfirmationModal/index.tsx
+++ b/src/components/Modal/TbtcMintingConfirmationModal/index.tsx
@@ -29,8 +29,8 @@ import {
   useRevealMultipleDepositsTransaction,
 } from "../../../hooks/tbtc"
 import { BigNumber } from "ethers"
-import { formatTokenAmount } from "../../../utils/formatAmount"
 import { getChainIdentifier } from "../../../threshold-ts/utils"
+import { InlineTokenBalance } from "../../TokenBalance"
 
 export interface TbtcMintingConfirmationModalProps extends BaseModalProps {
   utxos: UnspentTransactionOutput[]
@@ -104,16 +104,20 @@ const TbtcMintingConfirmationModal: FC<TbtcMintingConfirmationModalProps> = ({
       <ModalCloseButton />
       <ModalBody>
         <InfoBox variant="modal" mb="6">
-          <H5 mb={4}>
-            You will initiate the minting of{" "}
-            <Skeleton
-              isLoaded={!!tBTCMintAmount}
-              w={!tBTCMintAmount ? "105px" : undefined}
-              display="inline-block"
-            >
-              {!!tBTCMintAmount ? formatTokenAmount(tBTCMintAmount) : "0"}
-            </Skeleton>{" "}
-            tBTC
+          <H5>You will initiate the minting of</H5>
+          {/*
+            We can't use `InlineTokenBalance` inside the above `H5` because
+            the tooltip won't work correctly- will display at the top and
+            center of the whole `H5` component not only above token amount.
+           */}
+          <H5 mb="4">
+            <Skeleton isLoaded={!!tBTCMintAmount} maxW="105px" as="span">
+              <InlineTokenBalance
+                tokenAmount={tBTCMintAmount}
+                tokenSymbol="tBTC"
+                withSymbol
+              />
+            </Skeleton>
           </H5>
           <BodyLg>
             Minting tBTC is a process that requires one transaction.

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -8,6 +8,7 @@ import {
   HStack,
   TextProps,
   useColorModeValue,
+  Tooltip,
 } from "@threshold-network/components"
 import { useWeb3React } from "@web3-react/core"
 import Icon from "./Icon"
@@ -24,6 +25,45 @@ export interface TokenBalanceProps {
   iconSize?: string
   isLarge?: boolean
   tokenFormat?: string
+  withHigherPrecision?: boolean
+  precision?: number
+  higherPrecision?: number
+}
+
+export const InlineTokenBalance: FC<TokenBalanceProps> = ({
+  withSymbol,
+  tokenDecimals,
+  tokenFormat,
+  tokenAmount,
+  tokenSymbol,
+  precision = 2,
+  higherPrecision = 6,
+}) => {
+  const _tokenAmount = useMemo(() => {
+    return formatTokenAmount(
+      tokenAmount || 0,
+      tokenFormat,
+      tokenDecimals,
+      precision
+    )
+  }, [tokenAmount, tokenFormat, tokenDecimals, precision])
+
+  const _tokenAmountWithHigherPrecision = useMemo(() => {
+    return formatTokenAmount(
+      tokenAmount || 0,
+      tokenFormat,
+      tokenDecimals,
+      higherPrecision
+    )
+  }, [tokenAmount, tokenFormat, tokenDecimals, higherPrecision])
+
+  return (
+    <Tooltip label={_tokenAmountWithHigherPrecision} placement="top">
+      <Box as="span">{`${_tokenAmount}${
+        withSymbol ? ` ${tokenSymbol}` : ""
+      }`}</Box>
+    </Tooltip>
+  )
 }
 
 const TokenBalance: FC<TokenBalanceProps & TextProps> = ({
@@ -37,6 +77,9 @@ const TokenBalance: FC<TokenBalanceProps & TextProps> = ({
   iconSize = "32px",
   isLarge,
   tokenFormat,
+  precision,
+  higherPrecision,
+  withHigherPrecision = false,
   ...restProps
 }) => {
   const { active } = useWeb3React()
@@ -56,7 +99,21 @@ const TokenBalance: FC<TokenBalanceProps & TextProps> = ({
       <HStack alignItems="center">
         {icon && <Icon as={icon} boxSize={iconSize} />}{" "}
         <BalanceTag {...restProps}>
-          {shouldRenderTokenAmount ? _tokenAmount : "--"}
+          {shouldRenderTokenAmount ? (
+            withHigherPrecision ? (
+              <InlineTokenBalance
+                tokenAmount={tokenAmount}
+                tokenFormat={tokenFormat}
+                tokenDecimals={tokenDecimals}
+                precision={precision}
+                withHigherPrecision
+              />
+            ) : (
+              _tokenAmount
+            )
+          ) : (
+            "--"
+          )}
           {withSymbol && tokenSymbol && (
             <SymbolTag as="span"> {tokenSymbol}</SymbolTag>
           )}

--- a/src/components/TokenBalanceCard/TokenBalanceCardTemplate.tsx
+++ b/src/components/TokenBalanceCard/TokenBalanceCardTemplate.tsx
@@ -11,7 +11,14 @@ type Props = {
   contract: Contract | null
 } & Pick<
   TokenBalanceProps,
-  "tokenDecimals" | "tokenFormat" | "usdBalance" | "withSymbol" | "tokenSymbol"
+  | "tokenDecimals"
+  | "tokenFormat"
+  | "usdBalance"
+  | "withSymbol"
+  | "tokenSymbol"
+  | "precision"
+  | "withHigherPrecision"
+  | "higherPrecision"
 >
 
 const TokenBalanceCardTemplate: FC<Props> = ({
@@ -23,6 +30,9 @@ const TokenBalanceCardTemplate: FC<Props> = ({
   tokenSymbol,
   tokenDecimals,
   tokenFormat,
+  withHigherPrecision,
+  precision,
+  higherPrecision,
   withSymbol = false,
   ...restProps
 }) => {
@@ -40,6 +50,9 @@ const TokenBalanceCardTemplate: FC<Props> = ({
         tokenDecimals={tokenDecimals}
         tokenFormat={tokenFormat}
         withUSDBalance
+        withHigherPrecision={withHigherPrecision}
+        precision={precision}
+        higherPrecision={higherPrecision}
       />
       {/* <AddToMetamaskButton contract={contract} /> */}
     </Card>

--- a/src/components/TokenBalanceCard/index.tsx
+++ b/src/components/TokenBalanceCard/index.tsx
@@ -6,13 +6,17 @@ import NuCircleBrand from "../../static/icons/NuCircleBrand"
 import T from "../../static/icons/Ttoken"
 import { useToken } from "../../hooks/useToken"
 import { tBTCFillBlack } from "../../static/icons/tBTCFillBlack"
+import { TokenBalanceProps } from "../TokenBalance"
 
-export interface TokenBalanceCardProps {
+export type TokenBalanceCardProps = {
   token: Exclude<Token, Token.TBTC>
   title?: string | JSX.Element
   tokenSymbol?: string
   withSymbol?: boolean
-}
+} & Pick<
+  TokenBalanceProps,
+  "precision" | "withHigherPrecision" | "higherPrecision"
+>
 
 const tokenToIconMap = {
   [Token.Keep]: KeepCircleBrand,

--- a/src/hooks/useTbtcState.ts
+++ b/src/hooks/useTbtcState.ts
@@ -24,7 +24,7 @@ export const useTbtcState: UseTbtcState = () => {
     updateState("mintingStep", MintingStep.ProvideData)
     updateState("tBTCMintAmount", undefined)
     updateState("thresholdNetworkFee", undefined)
-    updateState("bitcoinMinerFee", undefined)
+    updateState("mintingFee", undefined)
   }, [dispatch, updateState])
 
   return {

--- a/src/pages/tBTC/Bridge/MintingCard/MintingSuccess.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingSuccess.tsx
@@ -18,7 +18,7 @@ import tbtcSuccess from "../../../../static/images/tbtc-success.png"
 import TransactionDetailsTable from "../components/TransactionDetailsTable"
 import { useTBTCTokenAddress } from "../../../../hooks/useTBTCTokenAddress"
 import withOnlyConnectedWallet from "../../../../components/withOnlyConnectedWallet"
-import { formatTokenAmount } from "../../../../utils/formatAmount"
+import { InlineTokenBalance } from "../../../../components/TokenBalance"
 
 const MintingSuccessComponent: FC<{
   onPreviousStepClick: (previosuStep: MintingStep) => void
@@ -46,7 +46,13 @@ const MintingSuccessComponent: FC<{
       </InfoBox>
       <Stack spacing={4} mb={8}>
         <BodyLg>
-          You should receive {formatTokenAmount(tBTCMintAmount)} tBTC in around{" "}
+          You should receive{" "}
+          <InlineTokenBalance
+            tokenAmount={tBTCMintAmount}
+            withSymbol
+            tokenSymbol="tBTC"
+          />{" "}
+          in around{" "}
           <Box as="span" color="brand.500">
             1-3 hours
           </Box>

--- a/src/pages/tBTC/Bridge/MintingCard/MintingSuccess.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingSuccess.tsx
@@ -18,13 +18,13 @@ import tbtcSuccess from "../../../../static/images/tbtc-success.png"
 import TransactionDetailsTable from "../components/TransactionDetailsTable"
 import { useTBTCTokenAddress } from "../../../../hooks/useTBTCTokenAddress"
 import withOnlyConnectedWallet from "../../../../components/withOnlyConnectedWallet"
+import { formatTokenAmount } from "../../../../utils/formatAmount"
 
 const MintingSuccessComponent: FC<{
   onPreviousStepClick: (previosuStep: MintingStep) => void
 }> = ({ onPreviousStepClick }) => {
-  const { updateState } = useTbtcState()
+  const { tBTCMintAmount } = useTbtcState()
 
-  const { btcDepositAddress, ethAddress, btcRecoveryAddress } = useTbtcState()
   const tbtcTokenAddress = useTBTCTokenAddress()
 
   const onDismissButtonClick = () => {
@@ -46,7 +46,7 @@ const MintingSuccessComponent: FC<{
       </InfoBox>
       <Stack spacing={4} mb={8}>
         <BodyLg>
-          You should receive 1.2 tBTC in around{" "}
+          You should receive {formatTokenAmount(tBTCMintAmount)} tBTC in around{" "}
           <Box as="span" color="brand.500">
             1-3 hours
           </Box>

--- a/src/pages/tBTC/Bridge/TbtcBalanceCard.tsx
+++ b/src/pages/tBTC/Bridge/TbtcBalanceCard.tsx
@@ -19,6 +19,7 @@ export const TbtcBalanceCard: FC<ComponentProps<typeof Card>> = ({
       }
       tokenSymbol={"tBTC"}
       withSymbol={true}
+      withHigherPrecision={true}
       {...restProps}
     />
   )

--- a/src/pages/tBTC/Bridge/TransactionHistory/index.tsx
+++ b/src/pages/tBTC/Bridge/TransactionHistory/index.tsx
@@ -19,7 +19,7 @@ import emptyHistoryImageSrcDark from "../../../../static/images/tBTC-bridge-no-h
 import emptyHistoryImageSrcLight from "../../../../static/images/tBTC-bridge-no-history-light.svg"
 import ViewInBlockExplorer from "../../../../components/ViewInBlockExplorer"
 import { ExplorerDataType } from "../../../../utils/createEtherscanLink"
-import { formatSatoshi } from "../../../../utils/formatAmount"
+import { InlineTokenBalance } from "../../../../components/TokenBalance"
 
 const bridgeTxHistoryStatusToBadgeProps: Record<
   BridgeHistoryStatus,
@@ -98,7 +98,12 @@ export const TransactionHistoryTable: FC<{
             data.map((_) => (
               <Tr key={_.txHash}>
                 <Td py={4} px={2}>
-                  {formatSatoshi(_.amount)}
+                  <InlineTokenBalance
+                    tokenAmount={_.amount}
+                    // TODO: Remove once we update the `bridgeTxHistory` in
+                    // `TBTC` wrapper in threshold lib.
+                    tokenDecimals={8}
+                  />
                 </Td>
                 <Td py={4} px={2}>
                   <ViewInBlockExplorer

--- a/src/pages/tBTC/Bridge/components/TransactionDetailsTable.tsx
+++ b/src/pages/tBTC/Bridge/components/TransactionDetailsTable.tsx
@@ -2,7 +2,7 @@ import { BodySm, HStack } from "@threshold-network/components"
 import { useTbtcState } from "../../../../hooks/useTbtcState"
 import { Skeleton, Stack } from "@chakra-ui/react"
 import shortenAddress from "../../../../utils/shortenAddress"
-import { formatTokenAmount } from "../../../../utils/formatAmount"
+import { InlineTokenBalance } from "../../../../components/TokenBalance"
 
 const TransactionDetailsTable = () => {
   const { tBTCMintAmount, mintingFee, thresholdNetworkFee, ethAddress } =
@@ -14,7 +14,11 @@ const TransactionDetailsTable = () => {
         <BodySm color="gray.500">Amount To Be Minted</BodySm>
         <Skeleton isLoaded={!!tBTCMintAmount}>
           <BodySm color="gray.700">
-            {!!tBTCMintAmount ? formatTokenAmount(tBTCMintAmount) : "0"} tBTC
+            <InlineTokenBalance
+              tokenAmount={tBTCMintAmount}
+              tokenSymbol="tBTC"
+              withSymbol
+            />
           </BodySm>
         </Skeleton>
       </HStack>
@@ -22,7 +26,13 @@ const TransactionDetailsTable = () => {
         <BodySm color="gray.500">Minting Fee</BodySm>
         <Skeleton isLoaded={!!mintingFee}>
           <BodySm color="gray.700" display="flex" alignItems="center">
-            {!!mintingFee ? formatTokenAmount(mintingFee) : "0"} tBTC
+            <InlineTokenBalance
+              tokenAmount={mintingFee}
+              tokenSymbol="tBTC"
+              withSymbol
+              precision={6}
+              higherPrecision={8}
+            />
           </BodySm>
         </Skeleton>
       </HStack>
@@ -30,10 +40,13 @@ const TransactionDetailsTable = () => {
         <BodySm color="gray.500">Threshold Network Fee</BodySm>
         <Skeleton isLoaded={!!thresholdNetworkFee}>
           <BodySm color="gray.700" display="flex" alignItems="center">
-            {!!thresholdNetworkFee
-              ? formatTokenAmount(thresholdNetworkFee)
-              : "0"}{" "}
-            tBTC
+            <InlineTokenBalance
+              tokenAmount={thresholdNetworkFee}
+              tokenSymbol="tBTC"
+              withSymbol
+              precision={6}
+              higherPrecision={8}
+            />
           </BodySm>
         </Skeleton>
       </HStack>

--- a/src/pages/tBTC/Bridge/components/TransactionDetailsTable.tsx
+++ b/src/pages/tBTC/Bridge/components/TransactionDetailsTable.tsx
@@ -2,30 +2,27 @@ import { BodySm, HStack } from "@threshold-network/components"
 import { useTbtcState } from "../../../../hooks/useTbtcState"
 import { Skeleton, Stack } from "@chakra-ui/react"
 import shortenAddress from "../../../../utils/shortenAddress"
-import { formatSatoshi } from "../../../../utils/formatAmount"
+import { formatTokenAmount } from "../../../../utils/formatAmount"
 
 const TransactionDetailsTable = () => {
-  const { tBTCMintAmount, bitcoinMinerFee, thresholdNetworkFee, ethAddress } =
+  const { tBTCMintAmount, mintingFee, thresholdNetworkFee, ethAddress } =
     useTbtcState()
 
   return (
     <Stack spacing={2} mb={6}>
       <HStack justifyContent="space-between" alignItems="center">
-        <BodySm color="gray.500">Minted Amount</BodySm>
+        <BodySm color="gray.500">Amount To Be Minted</BodySm>
         <Skeleton isLoaded={!!tBTCMintAmount}>
           <BodySm color="gray.700">
-            {!!tBTCMintAmount ? formatSatoshi(tBTCMintAmount) : "0"} tBTC
+            {!!tBTCMintAmount ? formatTokenAmount(tBTCMintAmount) : "0"} tBTC
           </BodySm>
         </Skeleton>
       </HStack>
       <HStack justifyContent="space-between">
-        <BodySm color="gray.500">Bitcoin Miner Fee</BodySm>
-        <Skeleton isLoaded={!!bitcoinMinerFee}>
+        <BodySm color="gray.500">Minting Fee</BodySm>
+        <Skeleton isLoaded={!!mintingFee}>
           <BodySm color="gray.700" display="flex" alignItems="center">
-            {!!bitcoinMinerFee // TODO: remove trailing zeroes
-              ? formatSatoshi(bitcoinMinerFee, 6)
-              : "0"}{" "}
-            BTC
+            {!!mintingFee ? formatTokenAmount(mintingFee) : "0"} tBTC
           </BodySm>
         </Skeleton>
       </HStack>
@@ -33,10 +30,10 @@ const TransactionDetailsTable = () => {
         <BodySm color="gray.500">Threshold Network Fee</BodySm>
         <Skeleton isLoaded={!!thresholdNetworkFee}>
           <BodySm color="gray.700" display="flex" alignItems="center">
-            {!!thresholdNetworkFee // TODO: remove trailing zeroes
-              ? formatSatoshi(thresholdNetworkFee, 6)
+            {!!thresholdNetworkFee
+              ? formatTokenAmount(thresholdNetworkFee)
               : "0"}{" "}
-            BTC
+            tBTC
           </BodySm>
         </Skeleton>
       </HStack>

--- a/src/store/tbtc/tbtcSlice.ts
+++ b/src/store/tbtc/tbtcSlice.ts
@@ -35,7 +35,7 @@ interface TbtcState {
   tBTCMintAmount: string
   ethGasCost: number
   thresholdNetworkFee: string
-  bitcoinMinerFee: string
+  mintingFee: string
 
   transactionsHistory: FetchingState<BridgeTxHistory[]>
 }

--- a/src/types/tbtc.ts
+++ b/src/types/tbtc.ts
@@ -9,7 +9,7 @@ export type TbtcStateKey =
   | "tBTCMintAmount"
   | "ethGasCost"
   | "thresholdNetworkFee"
-  | "bitcoinMinerFee"
+  | "mintingFee"
   | "nextBridgeCrossingInUnix"
   | "walletPublicKeyHash"
   | "blindingFactor"
@@ -71,7 +71,7 @@ export interface UseTbtcState {
     tBTCMintAmount: string
     ethGasCost: number
     thresholdNetworkFee: string
-    bitcoinMinerFee: string
+    mintingFee: string
     resetDepositData: () => void
   }
 }

--- a/src/utils/__tests__/formatTokenAmount.test.ts
+++ b/src/utils/__tests__/formatTokenAmount.test.ts
@@ -1,0 +1,110 @@
+import { formatTokenAmount } from "../formatAmount"
+
+describe("Format token amount test", () => {
+  const decimals = 18
+  const precision = 2
+  const displayTildeBelow = 1
+
+  test("should display zero if it is zero", () => {
+    expect(formatTokenAmount(0)).toBe("0")
+  })
+
+  test.each`
+    amount
+    ${"1000000000000000"}
+    ${"9999900000000000"}
+    ${"9999999999999900"}
+    ${"5000000000000000"}
+    ${"50000000000000"}
+  `(
+    "should display `<` if an amount($amount) is less than decimals precision",
+    ({ amount }) => {
+      const result = formatTokenAmount(amount, undefined, decimals, precision)
+
+      expect(result).toBe("<0.01")
+    }
+  )
+
+  test("should display tilde only if the amount is below a given amount", () => {
+    const amount = "968000000000000000" // 0.968
+    const amount2 = "9967000000000000000" // 9.967
+    const amount3 = "12000000000000000" // 0.012
+
+    const result = formatTokenAmount(
+      amount,
+      undefined,
+      decimals,
+      precision,
+      displayTildeBelow
+    )
+
+    const result2 = formatTokenAmount(
+      amount2,
+      undefined,
+      decimals,
+      precision,
+      displayTildeBelow
+    )
+
+    const result3 = formatTokenAmount(
+      amount3,
+      undefined,
+      decimals,
+      precision,
+      displayTildeBelow
+    )
+
+    expect(result).toBe("~0.97")
+    expect(result2).toBe("9.97")
+    expect(result3).toBe("~0.01")
+  })
+
+  test("should not display the tilde if the rounded amount is equal to the given amount", () => {
+    const amount = "120000000000000000" // 0.12
+
+    const result = formatTokenAmount(
+      amount,
+      undefined,
+      decimals,
+      precision,
+      displayTildeBelow
+    )
+
+    expect(result).toBe("0.12")
+  })
+
+  test("should display amount with a given precision correctly", () => {
+    const precision = 6
+    const amount = "10000000000000" // 0.00001
+    const amount2 = "39980020000000" // 0.00003998002
+    const amount3 = "36000000000000" // 0,00003600000
+
+    const result = formatTokenAmount(
+      amount,
+      undefined,
+      decimals,
+      precision,
+      displayTildeBelow
+    )
+
+    const result2 = formatTokenAmount(
+      amount2,
+      undefined,
+      decimals,
+      precision,
+      displayTildeBelow
+    )
+
+    const result3 = formatTokenAmount(
+      amount3,
+      undefined,
+      decimals,
+      precision,
+      displayTildeBelow
+    )
+
+    expect(result).toBe("0.00001")
+    expect(result2).toBe("~0.00004")
+    expect(result3).toBe("0.000036")
+  })
+})

--- a/src/utils/formatAmount.ts
+++ b/src/utils/formatAmount.ts
@@ -1,16 +1,52 @@
 import { formatUnits } from "@ethersproject/units"
+import { BigNumber } from "ethers"
 import numeral from "numeral"
 
 export const formatNumeral = (number: string | number, format = "0,00.00") => {
-  return numeral(number).format(format, Math.floor)
+  return numeral(number).format(format)
 }
 
 export const formatTokenAmount = (
   rawAmount: number | string,
   format = "0,00.[0]0",
-  decimals = 18
+  decimals = 18,
+  precision = 2,
+  displayTildeBelow = 1
 ) => {
-  return formatNumeral(formatUnits(rawAmount, decimals), format)
+  const minAmountToDisplay = BigNumber.from(10).pow(decimals - precision)
+  const _rawAmount = BigNumber.from(rawAmount)
+
+  if (_rawAmount.isZero()) return "0"
+
+  if (minAmountToDisplay.gt(_rawAmount)) {
+    return `<0.${"0".repeat(precision - 1)}1`
+  }
+
+  let _format
+  if (precision && precision > 0) {
+    const precisionFormat = `[0]${"0".repeat(precision - 1)}`
+    _format = `0,00.${precisionFormat}`
+  } else {
+    _format = format
+  }
+
+  const tokenAmountInHumanReadableFormat = formatUnits(rawAmount, decimals)
+  const formattedAmount = formatNumeral(
+    tokenAmountInHumanReadableFormat,
+    _format
+  )
+
+  const amountFromFormattedValue = numeral(formattedAmount).value() ?? 0
+
+  if (
+    Number.parseFloat(amountFromFormattedValue.toString()) !==
+      Number.parseFloat(tokenAmountInHumanReadableFormat) &&
+    displayTildeBelow > amountFromFormattedValue
+  ) {
+    return `~${formattedAmount}`
+  }
+
+  return formattedAmount
 }
 
 export const formatFiatCurrencyAmount = (
@@ -22,11 +58,5 @@ export const formatFiatCurrencyAmount = (
 }
 
 export const formatSatoshi = (amount: number | string, precision = 2) => {
-  let precisionFormat = ""
-  if (precision > 0) {
-    precisionFormat = `[0]${"0".repeat(precision - 1)}`
-  }
-  const format = `0,00.${precisionFormat}`
-
-  return formatTokenAmount(amount, format, 8)
+  return formatTokenAmount(amount, undefined, 8, precision)
 }


### PR DESCRIPTION
Closes: #373
Closes: #371
Closes: #364 

This PR improves the token amount format- here we implement the solution which behaves like this:
`0.001` -> `<0.01`
`0.016` -> `~0.02`
and amounts with higher precision are displayed after hovering on the rounded values. Of course we can control the precision. So eg. for precision `4`: `0.001` -> `0.001`; `0.00009` -> `<0.0001` etc. See unit tests for more details.

Also, it updates the `getEstimatedFees` method in TBTC wrapper- return the amount of tBTC token that will be minted. Based on the smart contract code the amount to mint is `<btcDepositAmount> - <treasuryFee> - <optimisticMintFee>`. Return all values in ERC20 standart- 18 decimals.