### PR TITLE
Cosmetic improvements of the minting flow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,10 @@
       #root > div {
         min-height: 100vh;
       }
+      body,
+      html {
+        font-variant-ligatures: no-contextual;
+      }
     </style>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon-T.png" />

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
         min-height: 100vh;
       }
       body,
-      html {
+      * {
         font-variant-ligatures: no-contextual;
       }
     </style>

--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -37,7 +37,7 @@ const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
     <Form id={formId} mb={6}>
       <FormikInput
         name="ethAddress"
-        label="ETH address"
+        label="ETH Address"
         tooltip="ETH address is prepopulated with your wallet address. This is the address where you’ll receive your tBTC."
         mb={6}
       />

--- a/src/pages/tBTC/Bridge/UnmintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/UnmintingCard/ProvideData.tsx
@@ -32,7 +32,7 @@ const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
     <Form id={formId} mb={6}>
       <FormikInput
         name="ethAddress"
-        label="ETH address"
+        label="ETH Address"
         tooltip="ETH address is prepopulated with your wallet address. This is the address where you’ll receive your tBTC."
         mb={6}
       />


### PR DESCRIPTION
Closes: #365 
Closes: #368

# Changes:

### 1. Unify capitalization of address/Address labels in the provide data form. 
We will use `Address` with the capital `A` for eth address and btc recovery address.

### 2. Fix the `x` character

The `x` character was replaced with the multipliction symbol because this is how `Inter` font works. We can disable that with css property:
`font-variant-ligatures: no-contextual;`

Additional helpful links:
https://github.com/react-native-elements/react-native-elements/issues/2546
https://github.com/rsms/inter/issues/222