### PR TITLE
Add missing space char in minting timeline

### DIFF
--- a/src/pages/tBTC/Bridge/MintingCard/MintingTimeline.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingTimeline.tsx
@@ -30,7 +30,7 @@ export const MintingTimelineStep1: FC<MintingTimelineStepProps> = ({
       description={
         <>
           Provide an ETH address and a BTC Recovery address to generate an
-          unique BTC deposit address.
+          unique BTC deposit address.{" "}
           <Link isExternal href={ExternalHref.btcRecoveryAddress}>
             Read more
           </Link>


### PR DESCRIPTION
Closes: #366

There is a missing space char in the `Step 1` in the `MINTING TIMELINE` section, before `Read more` link. If there’s not enough space to add it, maybe we could remove the space char between more and an arrow.