### PR TITLE
Integrate second track deposit verification with Sentry telemetry

### DIFF
--- a/src/hooks/sentry/useCaptureMessage.ts
+++ b/src/hooks/sentry/useCaptureMessage.ts
@@ -1,10 +1,18 @@
 import { useCallback } from "react"
 import { featureFlags } from "../../constants"
 import * as sentry from "../../sentry"
+import { Primitive } from "@sentry/types"
 
 export const useCaptureMessage = () => {
-  return useCallback((message: string, params: { [key: string]: unknown }) => {
-    if (!featureFlags.SENTRY) return
-    sentry.captureMessage(message, params)
-  }, [])
+  return useCallback(
+    (
+      message: string,
+      params?: { [key: string]: unknown },
+      tags?: { [key: string]: Primitive }
+    ) => {
+      if (!featureFlags.SENTRY) return
+      sentry.captureMessage(message, params, tags)
+    },
+    []
+  )
 }

--- a/src/hooks/tbtc/useDepositTelemetry.ts
+++ b/src/hooks/tbtc/useDepositTelemetry.ts
@@ -15,11 +15,17 @@ export const useDepositTelemetry = (network: BitcoinNetwork) => {
         network
       )
 
-      captureMessage(`Generated deposit [${depositAddress}]`, {
-        ...deposit,
-        verificationStatus: status,
-        verificationResponse: response,
-      })
+      captureMessage(
+        `Generated deposit [${depositAddress}]`,
+        {
+          ...deposit,
+          verificationStatus: status,
+          verificationResponse: response,
+        },
+        {
+          "verification.status": status,
+        }
+      )
     },
     [verifyDepositAddress, network, captureMessage]
   )

--- a/src/hooks/tbtc/useDepositTelemetry.ts
+++ b/src/hooks/tbtc/useDepositTelemetry.ts
@@ -1,14 +1,26 @@
 import { useCallback } from "react"
 import { useCaptureMessage } from "../sentry"
 import { DepositScriptParameters } from "@keep-network/tbtc-v2.ts/dist/src/deposit"
+import { verifyDepositAddress } from "../../utils/verifyDepositAddress"
+import { BitcoinNetwork } from "../../threshold-ts/types"
 
-export const useDepositTelemetry = () => {
+export const useDepositTelemetry = (network: BitcoinNetwork) => {
   const captureMessage = useCaptureMessage()
 
   return useCallback(
-    (deposit: DepositScriptParameters, depositAddress: string) => {
-      captureMessage(`Generated deposit [${depositAddress}]`, deposit)
+    async (deposit: DepositScriptParameters, depositAddress: string) => {
+      const { status, response } = await verifyDepositAddress(
+        deposit,
+        depositAddress,
+        network
+      )
+
+      captureMessage(`Generated deposit [${depositAddress}]`, {
+        ...deposit,
+        verificationStatus: status,
+        verificationResponse: response,
+      })
     },
-    []
+    [verifyDepositAddress, network, captureMessage]
   )
 }

--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -93,7 +93,7 @@ export const ProvideDataComponent: FC<{
   const threshold = useThreshold()
   const { account } = useWeb3React()
   const { setDepositDataInLocalStorage } = useTBTCDepositDataFromLocalStorage()
-  const depositTelemetry = useDepositTelemetry()
+  const depositTelemetry = useDepositTelemetry(threshold.tbtc.bitcoinNetwork)
 
   const onSubmit = async (values: FormValues) => {
     setSubmitButtonLoading(true)

--- a/src/sentry/index.ts
+++ b/src/sentry/index.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/react"
 import { BrowserTracing } from "@sentry/tracing"
 import { getEnvVariable } from "../utils/getEnvVariable"
 import { EnvVariable } from "../enums"
+import { Primitive } from "@sentry/types"
 
 export const init = () => {
   const dsn = getEnvVariable(EnvVariable.SENTRY_DSN)
@@ -15,12 +16,16 @@ export const init = () => {
 
 export const captureMessage = (
   message: string,
-  params: { [key: string]: unknown }
+  params?: { [key: string]: unknown },
+  tags?: { [key: string]: Primitive }
 ) => {
   Sentry.withScope((scope) => {
-    // eslint-disable-next-line guard-for-in
-    for (const key in params) {
-      scope.setExtra(key, params[key])
+    if (params) {
+      scope.setExtras(params)
+    }
+
+    if (tags) {
+      scope.setTags(tags)
     }
 
     Sentry.captureMessage(message)

--- a/src/utils/verifyDepositAddress.ts
+++ b/src/utils/verifyDepositAddress.ts
@@ -4,7 +4,7 @@ import { BitcoinNetwork } from "../threshold-ts/types"
 
 export interface VerificationOutcome {
   status: "valid" | "invalid" | "error"
-  response: any
+  response: unknown
 }
 
 export const verifyDepositAddress = async (

--- a/src/utils/verifyDepositAddress.ts
+++ b/src/utils/verifyDepositAddress.ts
@@ -1,0 +1,38 @@
+import axios from "axios"
+import { DepositScriptParameters } from "@keep-network/tbtc-v2.ts/dist/src/deposit"
+import { BitcoinNetwork } from "../threshold-ts/types"
+
+export interface VerificationOutcome {
+  status: "valid" | "invalid" | "error"
+  response: any
+}
+
+export const verifyDepositAddress = async (
+  deposit: DepositScriptParameters,
+  depositAddress: string,
+  network: BitcoinNetwork
+): Promise<VerificationOutcome> => {
+  const endpoint = `https://us-central1-keep-test-f3e0.cloudfunctions.net/verify-deposit-address`
+
+  const { depositor, blindingFactor, refundPublicKeyHash, refundLocktime } =
+    deposit
+
+  try {
+    const response = await axios.get(
+      `${endpoint}/json/${network}/latest/${depositor.identifierHex}/${blindingFactor}/${refundPublicKeyHash}/${refundLocktime}`,
+      { timeout: 10000 } // 10s
+    )
+
+    const match = response.data.address === depositAddress
+
+    return {
+      status: match ? "valid" : "invalid",
+      response: response.data,
+    }
+  } catch (err) {
+    return {
+      status: "error",
+      response: err,
+    }
+  }
+}


### PR DESCRIPTION
Here we integrate the second track deposit address verification with deposit telemetry. The verification calls a Cloud Function deployed on `keep-test` and is done right before sending deposit data to Sentry. The verification outcome is attached to the telemetry data as two additional fields:
- `verificationStatus` which can have three different values
  - `valid`: verification service responded with the same address as the generated one
  - `invalid`: verification service responded with a different address
  - `error`: request or verification service error
- `verificationResponse` which holds the complete request outcome

The verification service availability does not impact the dApp functionality. The deposit flow and telemetry works even if something is wrong on service side.