### PR TITLE
Prefer tBTC over TBTC in all user-facing copy

### DIFF
--- a/src/pages/tBTC/Bridge/components/TbtcMintingCardTitle.tsx
+++ b/src/pages/tBTC/Bridge/components/TbtcMintingCardTitle.tsx
@@ -24,8 +24,8 @@ export const TbtcMintingCardTitle: FC<{
       )}
       <Icon boxSize="32px" as={tBTCFillBlack} />
       <LabelSm textTransform="uppercase">
-        {mintingType === TbtcMintingType.mint && "TBTC - Minting Process"}
-        {mintingType === TbtcMintingType.unmint && "TBTC - Unminting Process"}
+        {mintingType === TbtcMintingType.mint && "tBTC - Minting Process"}
+        {mintingType === TbtcMintingType.unmint && "tBTC - Unminting Process"}
       </LabelSm>
     </Stack>
   )

--- a/src/pages/tBTC/index.tsx
+++ b/src/pages/tBTC/index.tsx
@@ -12,7 +12,7 @@ MainTBTCPage.route = {
   path: "tBTC",
   index: true,
   pages: [TBTCBridge, HowItWorksPage],
-  title: "TBTC",
+  title: "tBTC",
   isPageEnabled: featureFlags.TBTC_V2,
 }
 


### PR DESCRIPTION
The codebase still mixes `tBTC`, `TBTC`, and `Tbtc` in variables names. I'm considering adding an explicit linter rule for those, but will save it for later 🤪