### PR TITLE
Refactor `useTBTCDepositDataFromLocalStorage` to use callbacks

### DIFF
--- a/src/hooks/tbtc/useTBTCDepositDataFromLocalStorage.ts
+++ b/src/hooks/tbtc/useTBTCDepositDataFromLocalStorage.ts
@@ -1,4 +1,5 @@
 import { useWeb3React } from "@web3-react/core"
+import { useCallback } from "react"
 import { useLocalStorage } from "../useLocalStorage"
 
 export type TBTCDepositData = {
@@ -20,23 +21,26 @@ export const useTBTCDepositDataFromLocalStorage = () => {
   const [tBTCDepositData, setTBTCDepositData] =
     useLocalStorage<TBTCLocalStorageDepositData>(`tBTCDepositData`, {})
 
-  const setDepositDataInLocalStorage = (depositData: TBTCDepositData) => {
-    if (account) {
-      const newLocalStorageData = {
-        ...tBTCDepositData,
-        [account]: depositData,
+  const setDepositDataInLocalStorage = useCallback(
+    (depositData: TBTCDepositData) => {
+      if (account) {
+        const newLocalStorageData = {
+          ...tBTCDepositData,
+          [account]: depositData,
+        }
+        setTBTCDepositData(newLocalStorageData)
       }
-      setTBTCDepositData(newLocalStorageData)
-    }
-  }
+    },
+    [account, setTBTCDepositData]
+  )
 
-  const removeDepositDataFromLocalStorage = () => {
+  const removeDepositDataFromLocalStorage = useCallback(() => {
     const newLocalStorageData = {
       ...tBTCDepositData,
     }
     delete newLocalStorageData[`${account}`]
     setTBTCDepositData(newLocalStorageData)
-  }
+  }, [account, JSON.stringify(tBTCDepositData), setTBTCDepositData])
 
   return {
     tBTCDepositData,


### PR DESCRIPTION
After last changes there was a bug in step 2. It had an infinite `Waiting for funds to be sent...` loading in step 2, when the dApp used mocked bitcoin client. It look like it worked ok with electrum client, but the dApp still connected to the Electrum when it not needed to.

The problem was thet we've added a `removeDepositData` variable to the dependency array here:
https://github.com/threshold-network/token-dashboard/blob/e888db948a1a47107010b0b6a1399c585c0488ca/src/pages/tBTC/Bridge/MintingCard/MintingFlowRouter.tsx#L84

And it didn't work as expected because we haven't returned the `removeDepositDataFromLocalStorage` function from `useTBTCDepositDataFromLocalStorage` as a callback.

This PR refactor `removeDepositDataFromLocalStorage` and additionally `setDepositDataInLocalStorage` functions used in `useTBTCDepositDataFromLocalStorage` so that they are returned as callbacks.