### PR TITLE
Make ETH address field readonly

### DIFF
--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -19,6 +19,7 @@ import { BitcoinNetwork } from "../../../../threshold-ts/types"
 import { useTBTCDepositDataFromLocalStorage } from "../../../../hooks/tbtc"
 import withOnlyConnectedWallet from "../../../../components/withOnlyConnectedWallet"
 import { useDepositTelemetry } from "../../../../hooks/tbtc/useDepositTelemetry"
+import { isSameETHAddress } from "../../../../web3/utils"
 
 export interface FormValues {
   ethAddress: string
@@ -40,6 +41,7 @@ const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
         label="ETH address"
         tooltip="ETH address is prepopulated with your wallet address. This is the address where you’ll receive your tBTC."
         mb={6}
+        isReadOnly={true}
       />
       <FormikInput
         name="btcRecoveryAddress"
@@ -68,7 +70,7 @@ const MintingProcessForm = withFormik<MintingProcessFormProps, FormValues>({
     btcRecoveryAddress: btcRecoveryAddress,
     bitcoinNetwork: bitcoinNetwork,
   }),
-  validate: async (values) => {
+  validate: async (values, props) => {
     const errors: FormikErrors<FormValues> = {}
     errors.ethAddress = validateETHAddress(values.ethAddress)
     errors.btcRecoveryAddress = validateBTCAddress(
@@ -81,6 +83,7 @@ const MintingProcessForm = withFormik<MintingProcessFormProps, FormValues>({
     props.onSubmitForm(values)
   },
   displayName: "MintingProcessForm",
+  enableReinitialize: true,
 })(MintingProcessFormBase)
 
 export const ProvideDataComponent: FC<{
@@ -96,6 +99,11 @@ export const ProvideDataComponent: FC<{
   const depositTelemetry = useDepositTelemetry()
 
   const onSubmit = async (values: FormValues) => {
+    if (account && !isSameETHAddress(values.ethAddress, account)) {
+      throw new Error(
+        "The account used to generate the deposit address must be the same as the connected wallet."
+      )
+    }
     setSubmitButtonLoading(true)
     const depositScriptParameters =
       await threshold.tbtc.createDepositScriptParameters(


### PR DESCRIPTION
Closes: #403 
Closes: #407 

The dApp allows user to create a deposit address using address other than his own. We shouldn't allow this because after user sends his funds to the deposit address he won't be able to reveal the deposit. It will throw an error `Wrong 32-byte script hash`.

We are adding two things:
- making eth address readonly,
- add a `throw error` in onSubmit function just in case someone manage to submit the form with a different address.

**Additional notes:**
We also add `enableReinitialize` option to the formik form so that it is reinitialized with a new initial value (which is eth address) when the address change. (this closes #407)