### PR TITLE
Add info about minimum deposit value

### DIFF
--- a/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
@@ -53,8 +53,8 @@ const MakeDepositComponent: FC<{
         subTitle="Make your BTC deposit"
       />
       <BodyMd color="gray.500" mb={6}>
-        Use this generated address to send any amount of BTC you want to mint as
-        tBTC.
+        Use this generated address to send any amount larger than 0.01&nbsp;BTC,
+        to mint as tBTC.
       </BodyMd>
       <BodyMd color="gray.500" mb={6}>
         This address is an unique generated address based on the data you

--- a/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
@@ -53,8 +53,8 @@ const MakeDepositComponent: FC<{
         subTitle="Make your BTC deposit"
       />
       <BodyMd color="gray.500" mb={6}>
-        Use this generated address to send any amount larger than 0.01&nbsp;BTC,
-        to mint as tBTC.
+        Use this generated address to send minimum 0.01&nbsp;BTC, to mint as
+        tBTC.
       </BodyMd>
       <BodyMd color="gray.500" mb={6}>
         This address is an unique generated address based on the data you

--- a/src/pages/tBTC/Bridge/MintingCard/MintingTimeline.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingTimeline.tsx
@@ -55,7 +55,7 @@ export const MintingTimelineStep2: FC<MintingTimelineStepProps> = ({
       stepText="Step 2"
       helperLabelText="ACTION ON BITCOIN NETWORK"
       title="Make a BTC deposit"
-      description="Send any amount larger than 0.01&nbsp;BTC to this unique BTC Deposit Address. The amount you send will be minted as tBTC."
+      description="Send minimum 0.01&nbsp;BTC to this unique BTC Deposit Address. The amount you send will be minted as tBTC."
       imageSrc={tbtcMintingStep2}
       {...restProps}
     />

--- a/src/pages/tBTC/Bridge/MintingCard/MintingTimeline.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingTimeline.tsx
@@ -55,7 +55,7 @@ export const MintingTimelineStep2: FC<MintingTimelineStepProps> = ({
       stepText="Step 2"
       helperLabelText="ACTION ON BITCOIN NETWORK"
       title="Make a BTC deposit"
-      description="Send any amount of BTC to this unique BTC Deposit Address. The amount you send is the amount will be minted as tBTC."
+      description="Send any amount larger than 0.01&nbsp;BTC to this unique BTC Deposit Address. The amount you send will be minted as tBTC."
       imageSrc={tbtcMintingStep2}
       {...restProps}
     />


### PR DESCRIPTION
Closes: #390 

The dust threshold enforced by the minting contracts isn't displayed in the app, allowing users to mistakenly send ~$230 at today's prices, leaving it stuck for up to 9 months.

We are adding info about minimum deposit value (0.01 BTC) in step 2 of the minting flow and in minting timeline.

I've also added a non-breaking space (`&nbsp;`) between the value and `BTC` (`0.01&nbsp;BTC`) so that those two words alway stay in the same line.

Todo: 
- [ ] Make the error when doing a reveal more readable if too little BTC were sent. Also let the user know about the refund instructions.