### PR TITLE
Update `bridgeTxHistory` method in TBTC wrapper

### DIFF
--- a/src/hooks/tbtc/useSubsribeToDepositRevealedEvent.ts
+++ b/src/hooks/tbtc/useSubsribeToDepositRevealedEvent.ts
@@ -31,11 +31,15 @@ export const useSubscribeToDepositRevealedEvent = () => {
     ) => {
       if (!account || !isSameETHAddress(depositor, account)) return
 
+      const { amountToMint } = await threshold.tbtc.getEstimatedFees(
+        amount.toString()
+      )
+
       dispatch(
         tbtcSlice.actions.depositRevealed({
           fundingOutputIndex,
           fundingTxHash,
-          amount: amount.toString(),
+          amount: amountToMint,
           txHash: event.transactionHash,
           depositor: depositor,
           depositKey: threshold.tbtc.buildDepositKey(

--- a/src/pages/tBTC/Bridge/TransactionHistory/index.tsx
+++ b/src/pages/tBTC/Bridge/TransactionHistory/index.tsx
@@ -98,12 +98,7 @@ export const TransactionHistoryTable: FC<{
             data.map((_) => (
               <Tr key={_.txHash}>
                 <Td py={4} px={2}>
-                  <InlineTokenBalance
-                    tokenAmount={_.amount}
-                    // TODO: Remove once we update the `bridgeTxHistory` in
-                    // `TBTC` wrapper in threshold lib.
-                    tokenDecimals={8}
-                  />
+                  <InlineTokenBalance tokenAmount={_.amount} />
                 </Td>
                 <Td py={4} px={2}>
                   <ViewInBlockExplorer

--- a/src/threshold-ts/tbtc/index.ts
+++ b/src/threshold-ts/tbtc/index.ts
@@ -426,11 +426,7 @@ export class TBTC implements ITBTC {
     )
 
     const estimatedAmountToMintByDepositKey =
-      await this._calculateEstimatedAmountToMintForRevealedDeposits(
-        mintedDepositEvents.map((event) =>
-          (event.args?.depositKey as BigNumber).toHexString()
-        )
-      )
+      await this._calculateEstimatedAmountToMintForRevealedDeposits(depositKeys)
 
     const mintedDeposits = new Map(
       mintedDepositEvents.map((event) => [

--- a/src/threshold-ts/tbtc/index.ts
+++ b/src/threshold-ts/tbtc/index.ts
@@ -15,6 +15,7 @@ import {
   getContractPastEvents,
   getChainIdentifier,
   ZERO,
+  isSameETHAddress,
 } from "../utils"
 import {
   Client,
@@ -318,6 +319,32 @@ export class TBTC implements ITBTC {
   }
 
   getEstimatedFees = async (depositAmount: string) => {
+    const { depositTreasuryFeeDivisor, optimisticMintingFeeDivisor } =
+      await this._getDepositFees()
+
+    // https://github.com/keep-network/tbtc-v2/blob/main/solidity/contracts/bridge/Deposit.sol#L258-L260
+    const treasuryFee = BigNumber.from(depositTreasuryFeeDivisor).gt(0)
+      ? BigNumber.from(depositAmount).div(depositTreasuryFeeDivisor)
+      : ZERO
+
+    const { amountToMint, optimisticMintFee } =
+      this._calculateOptimisticMintingAmountAndFee(
+        BigNumber.from(depositAmount),
+        treasuryFee,
+        optimisticMintingFeeDivisor
+      )
+
+    return {
+      treasuryFee: treasuryFee.mul(this._satoshiMultiplier).toString(),
+      optimisticMintFee: optimisticMintFee.toString(),
+      amountToMint: amountToMint.toString(),
+    }
+  }
+
+  private _getDepositFees = async (): Promise<{
+    depositTreasuryFeeDivisor: BigNumber
+    optimisticMintingFeeDivisor: BigNumber
+  }> => {
     const calls: ContractCall[] = [
       {
         interface: new Interface(BridgeArtifact.abi),
@@ -336,15 +363,25 @@ export class TBTC implements ITBTC {
     const [depositParams, _optimisticMintingFeeDivisor] =
       await this._multicall.aggregate(calls)
 
-    const depositTreasuryFeeDivisor = depositParams.depositTreasuryFeeDivisor
-    const optimisticMintingFeeDivisor = _optimisticMintingFeeDivisor[0]
+    const depositTreasuryFeeDivisor = BigNumber.from(
+      depositParams.depositTreasuryFeeDivisor
+    )
+    const optimisticMintingFeeDivisor = BigNumber.from(
+      _optimisticMintingFeeDivisor[0]
+    )
 
-    // https://github.com/keep-network/tbtc-v2/blob/main/solidity/contracts/bridge/Deposit.sol#L258-L260
-    const treasuryFee = BigNumber.from(depositTreasuryFeeDivisor).gt(0)
-      ? BigNumber.from(depositAmount).div(depositTreasuryFeeDivisor)
-      : ZERO
+    return {
+      depositTreasuryFeeDivisor,
+      optimisticMintingFeeDivisor,
+    }
+  }
 
-    const amountToMint = BigNumber.from(depositAmount)
+  private _calculateOptimisticMintingAmountAndFee = (
+    depositAmount: BigNumber,
+    treasuryFee: BigNumber,
+    optimisticMintingFeeDivisor: BigNumber
+  ) => {
+    const amountToMint = depositAmount
       .sub(treasuryFee)
       .mul(this._satoshiMultiplier)
 
@@ -354,9 +391,8 @@ export class TBTC implements ITBTC {
       : ZERO
 
     return {
-      treasuryFee: treasuryFee.mul(this._satoshiMultiplier).toString(),
-      optimisticMintFee: optimisticMintFee.toString(),
-      amountToMint: amountToMint.sub(optimisticMintFee).toString(),
+      optimisticMintFee: optimisticMintFee,
+      amountToMint: amountToMint.sub(optimisticMintFee),
     }
   }
 
@@ -384,33 +420,55 @@ export class TBTC implements ITBTC {
     const revealedDeposits = await this._findAllRevealedDeposits(depositor)
     const depositKeys = revealedDeposits.map((_) => _.depositKey)
 
+    const mintedDepositEvents = await this._findAllMintedDeposits(
+      depositor,
+      depositKeys
+    )
+
+    const estimatedAmountToMintByDepositKey =
+      await this._calculateEstimatedAmountToMintForRevealedDeposits(
+        mintedDepositEvents.map((event) =>
+          (event.args?.depositKey as BigNumber).toHexString()
+        )
+      )
+
     const mintedDeposits = new Map(
-      (await this._findAllMintedDeposits(depositor, depositKeys)).map((_) => [
-        (_.args?.depositKey as BigNumber).toHexString(),
-        { txHash: _.transactionHash },
+      mintedDepositEvents.map((event) => [
+        (event.args?.depositKey as BigNumber).toHexString(),
+        event.transactionHash,
       ])
     )
 
     const cancelledDeposits = new Map(
-      (await this._findAllCancelledDeposits(depositKeys)).map((_) => [
-        (_.args?.depositKey as BigNumber).toHexString(),
-        { txHash: _.transactionHash },
+      (await this._findAllCancelledDeposits(depositKeys)).map((event) => [
+        (event.args?.depositKey as BigNumber).toHexString(),
+        event.transactionHash,
       ])
+    )
+    const mintedAmountByTxHash = new Map(
+      await Promise.all(
+        Array.from(mintedDeposits.values()).map((txHash) =>
+          this._getMintedAmountFromTxHash(txHash, depositor)
+        )
+      )
     )
 
     return revealedDeposits.map((deposit) => {
-      const { depositKey, amount, txHash: depositTxHash } = deposit
+      const { depositKey, txHash: depositTxHash } = deposit
       let status = BridgeHistoryStatus.PENDING
       let txHash = depositTxHash
+      let amount = estimatedAmountToMintByDepositKey.get(depositKey) ?? ZERO
+
       if (mintedDeposits.has(depositKey)) {
         status = BridgeHistoryStatus.MINTED
-        txHash = mintedDeposits.get(depositKey)?.txHash!
+        txHash = mintedDeposits.get(depositKey)!
+        amount = mintedAmountByTxHash.get(txHash)!
       } else if (cancelledDeposits.has(depositKey)) {
         status = BridgeHistoryStatus.ERROR
-        txHash = cancelledDeposits.get(depositKey)?.txHash!
+        txHash = cancelledDeposits.get(depositKey)!
       }
 
-      return { amount, txHash, status, depositKey }
+      return { amount: amount.toString(), txHash, status, depositKey }
     })
   }
 
@@ -443,6 +501,61 @@ export class TBTC implements ITBTC {
         }
       })
       .reverse()
+  }
+
+  private _calculateEstimatedAmountToMintForRevealedDeposits = async (
+    depositKeys: string[]
+  ): Promise<Map<string, BigNumber>> => {
+    const { optimisticMintingFeeDivisor } = await this._getDepositFees()
+
+    const deposits = (
+      await this._multicall.aggregate(
+        depositKeys.map((depositKey) => ({
+          interface: this.bridgeContract.interface,
+          address: this.bridgeContract.address,
+          method: "deposits",
+          args: [depositKey],
+        }))
+      )
+    ).map((deposit) => deposit[0]) as {
+      amount: BigNumber
+      treasuryFee: BigNumber
+    }[]
+
+    return new Map(
+      depositKeys.map((depositKey, index) => {
+        const deposit = deposits[index]
+        return [
+          depositKey,
+          this._calculateOptimisticMintingAmountAndFee(
+            deposit.amount,
+            deposit.treasuryFee,
+            optimisticMintingFeeDivisor
+          ).amountToMint,
+        ]
+      })
+    )
+  }
+
+  private _getMintedAmountFromTxHash = async (
+    optimisticMintingFinalizedTxHash: string,
+    depositor: string
+  ): Promise<[string, BigNumber]> => {
+    const receipt = await this.tokenContract.provider.getTransactionReceipt(
+      optimisticMintingFinalizedTxHash
+    )
+
+    // There is only one transfer to depositor account.
+    const transferEvent = receipt.logs
+      .filter((log) => isSameETHAddress(log.address, this._token.address))
+      .map((log) => this._token.interface.parseLog(log))
+      .filter((log) => log.name === "Transfer")
+      .find((log) => isSameETHAddress(log.args.to, depositor))
+
+    return [
+      optimisticMintingFinalizedTxHash,
+      BigNumber.from(transferEvent?.args?.value ?? ZERO),
+    ]
   }
 
   private _findAllMintedDeposits = async (


### PR DESCRIPTION
Closes: #388

Take into account fees while calculating an amount. If it's a revealed deposit we need to get `treasuryFee` param from onchain `DepositRequest` struct because the `treausuryFee` depends on the deposited amount and `depositTreasuryFeeDivisor` param which is governable so it means it may change over time.

If it's an already minted deposit the only way to get the exact amount of minted `tBTC` is:
1. Get all logs from transaction in which the optimistic minting was completed.
2. Find `Transfer` events from tBTC token contract based on logs.
3. Find `Transfer` event where `to` param is equal to the depositor address. There is only one transfer to the depositor account.