### PR TITLE
Fix deposit flow

### DIFF
--- a/src/hooks/tbtc/useTBTCDepositDataFromLocalStorage.ts
+++ b/src/hooks/tbtc/useTBTCDepositDataFromLocalStorage.ts
@@ -1,4 +1,5 @@
 import { useWeb3React } from "@web3-react/core"
+import { useCallback } from "react"
 import { useLocalStorage } from "../useLocalStorage"
 
 export type TBTCDepositData = {
@@ -20,23 +21,26 @@ export const useTBTCDepositDataFromLocalStorage = () => {
   const [tBTCDepositData, setTBTCDepositData] =
     useLocalStorage<TBTCLocalStorageDepositData>(`tBTCDepositData`, {})
 
-  const setDepositDataInLocalStorage = (depositData: TBTCDepositData) => {
-    if (account) {
-      const newLocalStorageData = {
-        ...tBTCDepositData,
-        [account]: depositData,
+  const setDepositDataInLocalStorage = useCallback(
+    (depositData: TBTCDepositData) => {
+      if (account) {
+        const newLocalStorageData = {
+          ...tBTCDepositData,
+          [account]: depositData,
+        }
+        setTBTCDepositData(newLocalStorageData)
       }
-      setTBTCDepositData(newLocalStorageData)
-    }
-  }
+    },
+    [account, setTBTCDepositData]
+  )
 
-  const removeDepositDataFromLocalStorage = () => {
+  const removeDepositDataFromLocalStorage = useCallback(() => {
     const newLocalStorageData = {
       ...tBTCDepositData,
     }
     delete newLocalStorageData[`${account}`]
     setTBTCDepositData(newLocalStorageData)
-  }
+  }, [account, JSON.stringify(tBTCDepositData), setTBTCDepositData])
 
   return {
     tBTCDepositData,

--- a/src/hooks/tbtc/useTBTCDepositDataFromLocalStorage.ts
+++ b/src/hooks/tbtc/useTBTCDepositDataFromLocalStorage.ts
@@ -1,46 +1,36 @@
 import { useWeb3React } from "@web3-react/core"
 import { useCallback } from "react"
 import { useLocalStorage } from "../useLocalStorage"
-
-export type TBTCDepositData = {
-  ethAddress: string
-  blindingFactor: string
-  btcRecoveryAddress: string
-  walletPublicKeyHash: string
-  refundLocktime: string
-  btcDepositAddress: string
-}
-
-export type TBTCLocalStorageDepositData = {
-  [address: string]: TBTCDepositData
-}
+import {
+  key,
+  write,
+  removeDataForAccount,
+  TBTCDepositData,
+  TBTCLocalStorageDepositData,
+} from "../../utils/tbtcLocalStorageData"
 
 export const useTBTCDepositDataFromLocalStorage = () => {
   const { account } = useWeb3React()
 
-  const [tBTCDepositData, setTBTCDepositData] =
-    useLocalStorage<TBTCLocalStorageDepositData>(`tBTCDepositData`, {})
+  const [tBTCDepositData] = useLocalStorage<TBTCLocalStorageDepositData>(
+    key,
+    {}
+  )
 
   const setDepositDataInLocalStorage = useCallback(
     (depositData: TBTCDepositData) => {
-      if (account) {
-        const newLocalStorageData = {
-          ...tBTCDepositData,
-          [account]: depositData,
-        }
-        setTBTCDepositData(newLocalStorageData)
-      }
+      if (!account) return
+
+      write(account, depositData, tBTCDepositData)
     },
-    [account, setTBTCDepositData]
+    [account, JSON.stringify(tBTCDepositData)]
   )
 
   const removeDepositDataFromLocalStorage = useCallback(() => {
-    const newLocalStorageData = {
-      ...tBTCDepositData,
-    }
-    delete newLocalStorageData[`${account}`]
-    setTBTCDepositData(newLocalStorageData)
-  }, [account, JSON.stringify(tBTCDepositData), setTBTCDepositData])
+    if (!account) return
+
+    removeDataForAccount(account, tBTCDepositData)
+  }, [account, JSON.stringify(tBTCDepositData)])
 
   return {
     tBTCDepositData,

--- a/src/hooks/useTbtcState.ts
+++ b/src/hooks/useTbtcState.ts
@@ -25,7 +25,8 @@ export const useTbtcState: UseTbtcState = () => {
     updateState("tBTCMintAmount", undefined)
     updateState("thresholdNetworkFee", undefined)
     updateState("mintingFee", undefined)
-  }, [dispatch, updateState])
+    updateState("utxo", undefined)
+  }, [updateState])
 
   return {
     ...tbtcState,

--- a/src/pages/tBTC/Bridge/MintingCard/MintingFlowRouter.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingFlowRouter.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react"
+import { FC, useEffect } from "react"
 import { Box, Flex, H5, Skeleton, Stack } from "@threshold-network/components"
 import { useTbtcState } from "../../../../hooks/useTbtcState"
 import { MintingStep } from "../../../../types/tbtc"
@@ -9,20 +9,17 @@ import { MakeDeposit } from "./MakeDeposit"
 import { useTBTCBridgeContractAddress } from "../../../../hooks/useTBTCBridgeContractAddress"
 import { useWeb3React } from "@web3-react/core"
 import SubmitTxButton from "../../../../components/SubmitTxButton"
-import { useThreshold } from "../../../../contexts/ThresholdContext"
-import { UnspentTransactionOutput } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
 import { useModal } from "../../../../hooks/useModal"
 import { ModalType } from "../../../../enums"
 import { BridgeContractLink } from "../../../../components/tBTC"
 import { TbtcMintingCardTitle } from "../components/TbtcMintingCardTitle"
 import { useRemoveDepositData } from "../../../../hooks/tbtc/useRemoveDepositData"
+import { useAppDispatch } from "../../../../hooks/store"
+import { tbtcSlice } from "../../../../store/tbtc"
 
 const MintingFlowRouterBase = () => {
-  const { mintingStep, updateState, btcDepositAddress } = useTbtcState()
-  const threshold = useThreshold()
-  const [utxo, setUtxo] = useState<UnspentTransactionOutput | undefined>(
-    undefined
-  )
+  const dispatch = useAppDispatch()
+  const { mintingStep, updateState, btcDepositAddress, utxo } = useTbtcState()
   const removeDepositData = useRemoveDepositData()
   const { openModal } = useModal()
 
@@ -40,48 +37,9 @@ const MintingFlowRouterBase = () => {
   }
 
   useEffect(() => {
-    const findUtxos = async () => {
-      if (btcDepositAddress) {
-        const utxos = await threshold.tbtc.findAllUnspentTransactionOutputs(
-          btcDepositAddress
-        )
-        if (utxos && utxos.length > 0) {
-          // UTXOs returned from `findAllUndpentTransactionOutputs` are in
-          // reversed order so we have to get the last element of the `utxos`
-          // array to get the oldest utxo related to this deposit address.
-          const utxo = utxos.pop()
-          setUtxo(utxo)
-          // If there is at least one utxo we remove the interval, because we
-          // don't want to encourage sending multiple transactions to the same
-          // deposit address.
-          clearInterval(interval)
-
-          // check if deposit is revealed
-          const deposit = await threshold.tbtc.getRevealedDeposit(utxo!)
-
-          const isDepositRevealed = deposit.revealedAt !== 0
-
-          if (isDepositRevealed) {
-            updateState("mintingStep", MintingStep.ProvideData)
-            removeDepositData()
-          } else {
-            updateState("mintingStep", MintingStep.InitiateMinting)
-          }
-        } else {
-          // If there is no utxo then we display the `MakeDeposit` step to the
-          // user and still run the interval to check if the funds were sent.
-          updateState("mintingStep", MintingStep.Deposit)
-        }
-      }
-    }
-
-    findUtxos()
-    const interval = setInterval(async () => {
-      await findUtxos()
-    }, 10000)
-
-    return () => clearInterval(interval)
-  }, [btcDepositAddress, threshold, updateState, removeDepositData])
+    if (!btcDepositAddress) return
+    dispatch(tbtcSlice.actions.findUtxo({ btcDepositAddress }))
+  }, [btcDepositAddress, dispatch])
 
   switch (mintingStep) {
     case MintingStep.ProvideData: {

--- a/src/pages/tBTC/Bridge/MintingCard/MintingFlowRouter.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingFlowRouter.tsx
@@ -19,6 +19,7 @@ import { tbtcSlice } from "../../../../store/tbtc"
 
 const MintingFlowRouterBase = () => {
   const dispatch = useAppDispatch()
+  const { account } = useWeb3React()
   const { mintingStep, updateState, btcDepositAddress, utxo } = useTbtcState()
   const removeDepositData = useRemoveDepositData()
   const { openModal } = useModal()
@@ -37,9 +38,11 @@ const MintingFlowRouterBase = () => {
   }
 
   useEffect(() => {
-    if (!btcDepositAddress) return
-    dispatch(tbtcSlice.actions.findUtxo({ btcDepositAddress }))
-  }, [btcDepositAddress, dispatch])
+    if (!btcDepositAddress || !account) return
+    dispatch(
+      tbtcSlice.actions.findUtxo({ btcDepositAddress, depositor: account })
+    )
+  }, [btcDepositAddress, account, dispatch])
 
   switch (mintingStep) {
     case MintingStep.ProvideData: {

--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -140,6 +140,7 @@ export const ProvideDataComponent: FC<{
       refundLocktime: depositScriptParameters.refundLocktime,
       btcDepositAddress: depositAddress,
     })
+    updateState("mintingStep", MintingStep.Deposit)
   }
 
   return (

--- a/src/store/tbtc/effects.ts
+++ b/src/store/tbtc/effects.ts
@@ -1,6 +1,9 @@
 import { AppListenerEffectAPI } from "../listener"
 import { tbtcSlice } from "./tbtcSlice"
 import { isAddress, isAddressZero } from "../../web3/utils"
+import { MintingStep } from "../../types/tbtc"
+import { ONE_SEC_IN_MILISECONDS } from "../../utils/date"
+import { TaskAbortError } from "@reduxjs/toolkit"
 
 export const fetchBridgeTxHitoryEffect = async (
   action: ReturnType<typeof tbtcSlice.actions.requestBridgeTransactionHistory>,
@@ -29,4 +32,97 @@ export const fetchBridgeTxHitoryEffect = async (
       })
     )
   }
+}
+
+export const findUtxoEffect = async (
+  action: ReturnType<typeof tbtcSlice.actions.findUtxo>,
+  listenerApi: AppListenerEffectAPI
+) => {
+  const { btcDepositAddress } = action.payload
+
+  if (!btcDepositAddress) return
+
+  // Cancel any in-progress instances of this listener.
+  listenerApi.cancelActiveListeners()
+
+  const pollingTask = listenerApi.fork(async (forkApi) => {
+    try {
+      while (true) {
+        // Looking for utxo.
+        const utxos = await forkApi.pause(
+          listenerApi.extra.threshold.tbtc.findAllUnspentTransactionOutputs(
+            btcDepositAddress
+          )
+        )
+
+        if (!utxos || utxos.length === 0) {
+          // Bitcoin deposit address exists and there is no utxo for a given
+          // deposit address- this means someone wants to use this deposit
+          // address to mint tBTC. Redirect to step 2 and continue searching for
+          // utxo.
+
+          listenerApi.dispatch(
+            tbtcSlice.actions.updateState({
+              key: "mintingStep",
+              value: MintingStep.Deposit,
+            })
+          )
+          await forkApi.delay(10 * ONE_SEC_IN_MILISECONDS)
+          continue
+        }
+
+        // UTXOs returned from `findAllUnspentTransactionOutputs` are in
+        // reversed order so we have to get the last element of the `utxos`
+        // array to get the oldest utxo related to this deposit address.
+        const utxo = utxos.pop()!
+
+        // Check if deposit is revealed.
+        const deposit = await forkApi.pause(
+          listenerApi.extra.threshold.tbtc.getRevealedDeposit(utxo)
+        )
+
+        const isDepositRevealed = deposit.revealedAt !== 0
+
+        if (isDepositRevealed) {
+          // Deposit already revealed, force start from step 1 and remove deposit data.
+          // TODO: Remove deposit data.
+          listenerApi.dispatch(
+            tbtcSlice.actions.updateState({
+              key: "mintingStep",
+              value: MintingStep.ProvideData,
+            })
+          )
+        } else {
+          // UTXO exists for a given Bitcoin deposit address and deposit is not
+          // yet revealed. Redirect to step 3 to reveal the deposit and set
+          // utxo.
+          listenerApi.dispatch(
+            tbtcSlice.actions.updateState({
+              key: "mintingStep",
+              value: MintingStep.InitiateMinting,
+            })
+          )
+          listenerApi.dispatch(
+            tbtcSlice.actions.updateState({ key: "utxo", value: utxo })
+          )
+        }
+      }
+    } catch (err) {
+      if (!(err instanceof TaskAbortError)) {
+        console.error(`Failed to fetch utxo for ${btcDepositAddress}.`, err)
+      }
+    }
+  })
+
+  await listenerApi.condition((action) => {
+    if (!tbtcSlice.actions.updateState.match(action)) return false
+
+    const { key, value } = (
+      action as ReturnType<typeof tbtcSlice.actions.updateState>
+    ).payload
+    return key === "mintingStep" && value !== MintingStep.Deposit
+  })
+
+  // Stop polling task.
+  pollingTask.cancel()
 }

--- a/src/store/tbtc/tbtcSlice.ts
+++ b/src/store/tbtc/tbtcSlice.ts
@@ -13,6 +13,7 @@ import { BridgeHistoryStatus, BridgeTxHistory } from "../../threshold-ts/tbtc"
 import { featureFlags } from "../../constants"
 import { startAppListening } from "../listener"
 import { fetchBridgeTxHitoryEffect } from "./effects"
+import { UnspentTransactionOutput } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
 
 interface TbtcState {
   mintingType: TbtcMintingType
@@ -28,6 +29,7 @@ interface TbtcState {
   walletPublicKeyHash: string
   refundLocktime: string
   blindingFactor: string
+  utxo: UnspentTransactionOutput
 
   nextBridgeCrossingInUnix?: number
 

--- a/src/store/tbtc/tbtcSlice.ts
+++ b/src/store/tbtc/tbtcSlice.ts
@@ -12,7 +12,7 @@ import { FetchingState } from "../../types"
 import { BridgeHistoryStatus, BridgeTxHistory } from "../../threshold-ts/tbtc"
 import { featureFlags } from "../../constants"
 import { startAppListening } from "../listener"
-import { fetchBridgeTxHitoryEffect } from "./effects"
+import { fetchBridgeTxHitoryEffect, findUtxoEffect } from "./effects"
 import { UnspentTransactionOutput } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
 
 interface TbtcState {
@@ -124,6 +124,12 @@ export const tbtcSlice = createSlice({
         txHash,
       }
     },
+    findUtxo: (
+      state,
+      action: PayloadAction<{
+        btcDepositAddress: string
+      }>
+    ) => {},
   },
 })
 
@@ -135,6 +141,11 @@ export const registerTBTCListeners = () => {
   startAppListening({
     actionCreator: tbtcSlice.actions.requestBridgeTransactionHistory,
     effect: fetchBridgeTxHitoryEffect,
+  })
+
+  startAppListening({
+    actionCreator: tbtcSlice.actions.findUtxo,
+    effect: findUtxoEffect,
   })
 }
 

--- a/src/store/tbtc/tbtcSlice.ts
+++ b/src/store/tbtc/tbtcSlice.ts
@@ -128,6 +128,7 @@ export const tbtcSlice = createSlice({
       state,
       action: PayloadAction<{
         btcDepositAddress: string
+        depositor: string
       }>
     ) => {},
   },

--- a/src/tbtc/mock-bitcoin-client.ts
+++ b/src/tbtc/mock-bitcoin-client.ts
@@ -123,7 +123,7 @@ export class MockBitcoinClient implements Client {
         refundLocktime: refundLocktime,
       }
 
-      this.mockDepositTransaction(depositScriptParameters)
+      await this.mockDepositTransaction(depositScriptParameters)
     }
 
     return this._unspentTransactionOutputs.get(
@@ -172,7 +172,7 @@ export class MockBitcoinClient implements Client {
 
     const deposit2: Deposit = {
       ...depositScriptParameters,
-      amount: BigNumber.from("1000001"),
+      amount: BigNumber.from("1500000"),
     }
 
     const {

--- a/src/types/tbtc.ts
+++ b/src/types/tbtc.ts
@@ -1,3 +1,4 @@
+import { UnspentTransactionOutput } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
 import { UpdateStateActionPayload } from "./state"
 
 export type TbtcStateKey =
@@ -14,6 +15,7 @@ export type TbtcStateKey =
   | "walletPublicKeyHash"
   | "blindingFactor"
   | "refundLocktime"
+  | "utxo"
 
 export enum TbtcMintingType {
   mint = "MINT",
@@ -63,6 +65,7 @@ export interface UseTbtcState {
     refundLocktime: string
     blindingFactor: string
     walletPublicKeyHash: string
+    utxo: UnspentTransactionOutput
 
     updateState: (key: TbtcStateKey, value: any) => UpdateTbtcState
     nextBridgeCrossingInUnix?: number

--- a/src/utils/tbtcLocalStorageData.ts
+++ b/src/utils/tbtcLocalStorageData.ts
@@ -1,0 +1,43 @@
+import { writeStorage } from "@rehooks/local-storage"
+
+export type TBTCDepositData = {
+  ethAddress: string
+  blindingFactor: string
+  btcRecoveryAddress: string
+  walletPublicKeyHash: string
+  refundLocktime: string
+  btcDepositAddress: string
+}
+
+export type TBTCLocalStorageDepositData = {
+  [address: string]: TBTCDepositData
+}
+
+export const key = "tBTCDepositData"
+
+export function write(
+  account: string,
+  newDepositData: TBTCDepositData,
+  prevData: TBTCLocalStorageDepositData
+) {
+  if (!account) return
+
+  const newLocalStorageData = {
+    ...prevData,
+    [account]: newDepositData,
+  }
+
+  writeStorage<TBTCLocalStorageDepositData>(key, newLocalStorageData)
+}
+
+export function removeDataForAccount(
+  account: string,
+  prevData: TBTCLocalStorageDepositData
+) {
+  const newLocalStorageData = {
+    ...prevData,
+  }
+  delete newLocalStorageData[`${account}`]
+
+  writeStorage<TBTCLocalStorageDepositData>(key, newLocalStorageData)
+}


### PR DESCRIPTION
~Depends on: #392~

Previous implementation didn't work well due to unnecessary state updates caused by `setInterval` inside the `useEffect` hook. Here we move the redirection logic to the correct step of the deposit flow to the listener middleware for better handling async work.