### PR TITLE
Prefer tBTC over TBTC in all user-facing copy

### DIFF
--- a/src/pages/tBTC/Bridge/components/TbtcMintingCardTitle.tsx
+++ b/src/pages/tBTC/Bridge/components/TbtcMintingCardTitle.tsx
@@ -24,8 +24,8 @@ export const TbtcMintingCardTitle: FC<{
       )}
       <Icon boxSize="32px" as={tBTCFillBlack} />
       <LabelSm textTransform="uppercase">
-        {mintingType === TbtcMintingType.mint && "TBTC - Minting Process"}
-        {mintingType === TbtcMintingType.unmint && "TBTC - Unminting Process"}
+        {mintingType === TbtcMintingType.mint && "tBTC - Minting Process"}
+        {mintingType === TbtcMintingType.unmint && "tBTC - Unminting Process"}
       </LabelSm>
     </Stack>
   )

--- a/src/pages/tBTC/Bridge/components/TbtcMintingCardTitle.tsx
+++ b/src/pages/tBTC/Bridge/components/TbtcMintingCardTitle.tsx
@@ -1,10 +1,14 @@
 import { FC } from "react"
-import { Icon, Stack } from "@chakra-ui/react"
 import { HiArrowNarrowLeft } from "react-icons/all"
-import { LabelSm } from "@threshold-network/components"
+import { Icon, Stack, Box, LabelSm } from "@threshold-network/components"
 import { tBTCFillBlack } from "../../../../static/icons/tBTCFillBlack"
 import { useTbtcState } from "../../../../hooks/useTbtcState"
 import { MintingStep, TbtcMintingType } from "../../../../types/tbtc"
+
+const mintTypeToText: Record<TbtcMintingType, string> = {
+  [TbtcMintingType.mint]: "minting process",
+  [TbtcMintingType.unmint]: "unminting process",
+}
 
 export const TbtcMintingCardTitle: FC<{
   previousStep?: MintingStep
@@ -23,9 +27,11 @@ export const TbtcMintingCardTitle: FC<{
         />
       )}
       <Icon boxSize="32px" as={tBTCFillBlack} />
-      <LabelSm textTransform="uppercase">
-        {mintingType === TbtcMintingType.mint && "tBTC - Minting Process"}
-        {mintingType === TbtcMintingType.unmint && "tBTC - Unminting Process"}
+      <LabelSm>
+        <Box as="span" textTransform="lowercase">
+          t
+        </Box>
+        btc - {mintTypeToText[mintingType]}
       </LabelSm>
     </Stack>
   )

--- a/src/pages/tBTC/index.tsx
+++ b/src/pages/tBTC/index.tsx
@@ -12,7 +12,7 @@ MainTBTCPage.route = {
   path: "tBTC",
   index: true,
   pages: [TBTCBridge, HowItWorksPage],
-  title: "TBTC",
+  title: "tBTC",
   isPageEnabled: featureFlags.TBTC_V2,
 }
 


### PR DESCRIPTION
Updates made by @mhluongo  🙏.

Ref: #391
The codebase still mixes tBTC, TBTC, and Tbtc in variables names. I'm considering adding an explicit linter rule for those, but will save it for later 🤪.

Force the first letter(tBTC) to be lowercase. The `LabelSm`
component sets the text to uppercase by default.