### PR TITLE
Use thesis/gcp-storage-bucket-action from feature branch

### DIFF
--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -90,7 +90,11 @@ jobs:
       - uses: actions/download-artifact@v3
 
       - name: Deploy PR mainnet preview to GCP
-        uses: thesis/gcp-storage-bucket-action@v3.1.0
+        # Temporarily we run the action in version from `alpine-version-413.0.0`
+        # branch, which contains a fix for the issue introduced in the `414.0.0`
+        # version of the `cloud-sdk` (`rsync` fails for users with no
+        # `storage.buckets.get` permission).
+        uses: thesis/gcp-storage-bucket-action@alpine-version-413.0.0
         with:
           service-key: ${{ secrets.MAINNET_PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
           project: ${{ secrets.MAINNET_PREVIEW_GOOGLE_PROJECT_ID }}
@@ -112,7 +116,11 @@ jobs:
       - uses: actions/download-artifact@v3
 
       - name: Deploy mainnet build to GCP
-        uses: thesis/gcp-storage-bucket-action@v3.1.0
+        # Temporarily we run the action in version from `alpine-version-413.0.0`
+        # branch, which contains a fix for the issue introduced in the `414.0.0`
+        # version of the `cloud-sdk` (`rsync` fails for users with no
+        # `storage.buckets.get` permission).
+        uses: thesis/gcp-storage-bucket-action@alpine-version-413.0.0
         with:
           service-key: ${{ secrets.MAINNET_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
           project: ${{ secrets.MAINNET_GOOGLE_PROJECT_ID }}


### PR DESCRIPTION
We temporarily change the version of `thesis/gcp-storage-bucket-action` code used to publish the client image to the GCP. The version that we change to builds the action using the `413.0.0-alpine` version of the `cloud-sdk`. We want to do it because the latest version of the `cloud-sdk:alpine` resolves currently to `414.0.0-alpine`, which intoduced a problem with execution of the `rsync` command for requesters who do not have the `storage.buckets.get` permission. As we use `rsync` in the `gcp-storage-bucket-action` action, we would be affected by the issue if we would use the `v3.1.0` of the action (which uses latest `cloud-sdk:alpine`).

More info:
https://cloud.google.com/storage/docs/release-notes#January_19_2023 GoogleCloudPlatform/gsutil#1663
thesis/gcp-storage-bucket-action@ee8b6a9