### PR TITLE
Clean up the JSON modal copy

### DIFF
--- a/src/components/Modal/TbtcRecoveryFileModal/index.tsx
+++ b/src/components/Modal/TbtcRecoveryFileModal/index.tsx
@@ -69,8 +69,8 @@ const TbtcRecoveryFileModalModal: FC<
   }
 
   const titleText = isOnConfirmStep
-    ? "Are you sure you do not want to download the .JSON file?"
-    : "Download this .JSON file"
+    ? "Are you sure you do not want to download the JSON file?"
+    : "Download this JSON file"
 
   const bodyContent = isOnConfirmStep ? (
     <BodyLg>
@@ -81,11 +81,11 @@ const TbtcRecoveryFileModalModal: FC<
       <BodyLg mb={6}>
         This file is important to save in case you need to recover your funds.
         Keep it until you have successfully initiated minting. One deposit, one
-        .JSON file.
+        JSON file.
       </BodyLg>
       <BodyLg>
-        This file contains a wallet public key, a refund public key and a refund
-        lock time.
+        This file contains your BTC recovery address, the wallet public key, the
+        refund public key and the refund lock time of this deposit.
       </BodyLg>
     </>
   )

--- a/src/pages/tBTC/HowItWorks/JSONFileCard.tsx
+++ b/src/pages/tBTC/HowItWorks/JSONFileCard.tsx
@@ -7,23 +7,23 @@ import { ExternalHref } from "../../../enums"
 export const JSONFileCard: FC<ComponentProps<typeof Card>> = ({ ...props }) => {
   return (
     <Card {...props}>
-      <LabelSm mb="8">.json file for Fund recoveries</LabelSm>
+      <LabelSm mb="8">JSON file for fund recoveries</LabelSm>
       <BodySm mb="5">
-        The .JSON file is important to save in case you need to recover your
+        The JSON file is important to save in case you need to recover your
         funds.
       </BodySm>
       <BodySm mb="5">
-        It’s important to keep this .JSON file until you have successfully
+        It’s important to keep this JSON file until you have successfully
         initiated tBTC minting.
       </BodySm>
       <BodySm mb="5">
-        This file contains a wallet public key, a refund public key and a refund
-        lock time. It reconstructs the deposit address in case a very unlikely
-        incident were to happen.
+        This file contains your BTC recovery address, the wallet's public key,
+        the refund public key, and the refund lock time of this deposit. It can
+        be used to reconstruct the deposit address in case of system error.
       </BodySm>
       <BodySm mb="5">
-        Each new deposit will generate a new .JSON file. Take note: Recovery
-        time lock is currently 9 months.
+        Each new deposit will generate a new JSON file. Take note: Recovery time
+        lock is currently 9 months.
       </BodySm>
       <BodySm mb="5">
         Recovery guide can be found{" "}


### PR DESCRIPTION
Include the BTC recovery address and remove the non-idiomatic use of ".JSON", preferring just "JSON".

Closes #416