### PR TITLE
Add sentry support to the mainnet preview

### DIFF
--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -55,6 +55,8 @@ jobs:
           ELECTRUM_PROTOCOL: ${{ secrets.MAINNET_ELECTRUMX_PROTOCOL }}
           ELECTRUM_HOST: ${{ secrets.MAINNET_ELECTRUMX_HOST }}
           ELECTRUM_PORT: ${{ secrets.MAINNET_ELECTRUMX_PORT }}
+          SENTRY_SUPPORT: true
+          SENTRY_DSN: ${{ secrets.MAINNET_SENTRY_DSN }}
 
       - name: Build
         if: github.event_name == 'release'


### PR DESCRIPTION
We were missing the `SENTRY_SUPPORT` and `SENTRY_DSN` in one of the jobs in `dashboard-mainnet.yml`.