### PR TITLE
Update link to the recovery guide and copy

### DIFF
--- a/src/components/tBTC/TakeNoteList.tsx
+++ b/src/components/tBTC/TakeNoteList.tsx
@@ -36,11 +36,11 @@ export const TakeNoteList: FC<{ size?: "sm" | "md" }> = ({ size = "md" }) => {
         <List spacing="2">
           <ListItemWithIcon>
             <BodyComponent as="span">
-              You'll be able to mint tBTC{" "}
+              Your tBTC token will arrive in{" "}
               <Box as="span" color="brand.500">
-                ~1 to 3 hours
+                ~ 1 to 3 hours
               </Box>{" "}
-              after your BTC deposit.
+              after you initiate minting.
             </BodyComponent>
           </ListItemWithIcon>
         </List>

--- a/src/enums/externalHref.ts
+++ b/src/enums/externalHref.ts
@@ -27,6 +27,5 @@ export enum ExternalHref {
   tBTCBrdigeAudit = "https://leastauthority.com/blog/audits/audit-of-keep-network-tbtc-bridge-v2/",
   vendingMachineAudit = "https://www.certik.com/projects/threshold-network",
   thresholdStakingAudit = "https://chainsecurity.com/security-audit/threshold-network/",
-  // TODO: Add link to the recovery guide.
-  tBTCRecoveryGuide = "",
+  tBTCRecoveryGuide = "https://github.com/keep-network/tbtc-v2/blob/main/typescript/scripts/README.adoc",
 }

--- a/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MakeDeposit.tsx
@@ -124,7 +124,7 @@ const MakeDepositComponent: FC<{
             itemSubTitle: (
               <BodyMd color={useColorModeValue("gray.500", "gray.300")}>
                 Send the funds and come back to this dApp. You do not need to
-                wait for the BTC transaction to be mined
+                wait for the BTC transaction to be mined.
               </BodyMd>
             ),
           },

--- a/src/pages/tBTC/Bridge/MintingCard/MintingSuccess.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingSuccess.tsx
@@ -71,7 +71,7 @@ const MintingSuccessComponent: FC<{
       <TransactionDetailsTable />
 
       <Button onClick={onDismissButtonClick} isFullWidth mb={6} mt="10">
-        Dismiss
+        New Mint
       </Button>
     </>
   )

--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -156,7 +156,7 @@ export const ProvideDataComponent: FC<{
       <TbtcMintingCardTitle onPreviousStepClick={onPreviousStepClick} />
       <TbtcMintingCardSubTitle stepText="Step 1" subTitle="Provide Data" />
       <BodyMd color="gray.500" mb={12}>
-        Based on these two addresses, the system will generate for you an unique
+        Based on these two addresses, the system will generate for you a unique
         BTC deposit address. There is no minting limit.
       </BodyMd>
       <MintingProcessForm


### PR DESCRIPTION
Closes: #423 
Closes: #398 

This PR updates link to the recovery guide and copy on the tBTC page.