### PR TITLE
Bug Bounty program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,41 @@ If you identify vulnerabilities with any Threshold Network code, please email `s
 
 Throughout the reporting process, we expect researchers to honor an embargo period that may vary depending on the severity of the disclosure. This ensures that we have the opportunity to fix any issues, identify further issues (if any), and inform our users.
 
-Sometimes vulnerabilities are more sensitive in nature and require extra precautions. We are happy to work together to use a more secure medium, such as Signal. Email `security@threshold.network` and we will coordinate a communication channel that we're both comfortable with.
+Sometimes vulnerabilities are more sensitive in nature and require extra precautions. We are happy to work together to use a more secure medium, such as Signal. Email security@threshold.network and we will coordinate a communication channel that we're both comfortable with.
 
-A great place to begin your research is by working on our testnet. Please see our [documentation](https://docs.threshold.network/) to get started. We ask that you please respect network machines and their owners. If you find a vulnerability that you suspect has given you access to a machine against the owner's permission, stop what you're doing and immediately email `security@threshold.network`.
+A great place to begin your research is by working on our testnet. Please see our [documentation](https://docs.threshold.network) to get started. We ask that you please respect network machines and their owners. If you find a vulnerability that you suspect has given you access to a machine against the owner's permission, stop what you're doing and immediately email `security@threshold.network`.
+
+The Threshold team will make a best effort to respond to a new report **within 48 hours**. This response may be a simple acknowledgement that the report was received, or may be an initial assessment from the team. Unless the report is assessed as irrelevant or incorrect, this response will include expected next steps and communication time frames from the Threshold team.
+
+The Threshold team will try to make an initial assessment of a bug's relevance, severity, and exploitability, and communicate this back to the reporter.
+
+The Threshold DAO does have a bug bounty available, which is dispensed on a case-by-case basis.
+
+## Bug Bounty Program
+
+The following Bug Bounty amounts were approved by the DAO in [TIP-041](https://forum.threshold.network/t/tip-041-establish-a-bug-bounty-program/453) proposal:
+
+- Critical: Up to $500,000 in T tokens.
+- High: Up to $50,000 in T tokens.
+- Medium: Up to $5,000 in T tokens.
+- Low: Up to $500 in T tokens.
+
+The following attacks are excluded from the Bug Bounty program:
+
+- Attacks that the reporter has already exploited themselves, leading to damage.
+- Attacks requiring access to leaked keys/credentials.
+- Basic economic governance attacks (e.g. 51% attack).
+- Lack of liquidity.
+- Sybil attacks.
+
+The following activities are prohibited by this bug bounty program:
+
+- Any testing with mainnet or public testnet contracts; all testing should be done on private testnets.
+- Attempting phishing or other social engineering attacks against our contributors and/or users.
+- Any denial of service attacks.
+- Automated testing of services that generates significant amounts of traffic.
+- Public disclosure of an unpatched vulnerability in an embargoed bounty.
+
+Rewards are distributed according to the impact of the vulnerability based on the [Immunefi Vulnerability Severity Classification System V2.2](https://immunefi.com/immunefi-vulnerability-severity-classification-system-v2-2/). This is a simplified 5-level scale, with separate scales for websites/apps, smart contracts, and blockchains/DLTs, focusing on the impact of the vulnerability reported.
+
+Threshold DAO is currently in the process of establishing a Bug Bounty program on Immunefi.


### PR DESCRIPTION
See https://github.com/threshold-network/solidity-contracts/pull/137 

With tBTC v2 launched, we need to have the bug bounty approved by the DAO in TIP-041 well described and easily available to find.

Given the DAO is in progress of establishing a bug bounty with Immunefi, this document may need further updates in the course of the next 2/3 weeks.