### PR TITLE
[Backport] Fix fetching legacy Keep stake

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,5 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom"
+
+jest.mock("@keep-network/tbtc-v2.ts/dist/src", () => ({}))

--- a/src/threshold-ts/staking/__test__/staking.test.ts
+++ b/src/threshold-ts/staking/__test__/staking.test.ts
@@ -166,7 +166,12 @@ describe("Staking test", () => {
     }
     const amount = BigNumber.from("100")
     const stakes = { tStake: amount, keepInTStake: amount, nuInTStake: amount }
-    const eligibleKeepStake = amount.add("100")
+    // Type of Multicall result is `Result` from `ethers`. A `Result` is an
+    // array, so each value can be accessed as a positional argument.
+    // Additionally, if values are named, the identical object as its positional
+    // value can be accessed by its name. Here we simulate the return value from
+    // `Multicall` service.
+    const eligibleKeepStake = { balance: amount.add("100") }
     const nuStakerInfo = {
       stakingProvider: stakingProvider,
       value: amount.add(300),
@@ -218,10 +223,10 @@ describe("Staking test", () => {
     ])
 
     expect(vendingMachines.keep.convertToT).toHaveBeenCalledWith(
-      eligibleKeepStake
+      eligibleKeepStake.balance.toString()
     )
     expect(vendingMachines.nu.convertToT).toHaveBeenCalledWith(
-      nuStakerInfo.value
+      nuStakerInfo.value.toString()
     )
 
     expect(result).toEqual({

--- a/src/threshold-ts/staking/index.ts
+++ b/src/threshold-ts/staking/index.ts
@@ -185,7 +185,7 @@ export class Staking implements IStaking {
       },
     ]
 
-    const [rolesOf, stakes, eligibleKeepStake] =
+    const [rolesOf, stakes, { balance: eligibleKeepStake }] =
       await this._multicall.aggregate(multicalls)
 
     const { owner, authorizer, beneficiary } = rolesOf
@@ -195,16 +195,18 @@ export class Staking implements IStaking {
     // The NU staker can have only one stake.
     const { stakingProvider: nuStakingProvider, value: nuStake } =
       await this._legacyNuStaking.stakerInfo(owner)
+
     const possibleNuTopUpInT =
       isAddress(nuStakingProvider) &&
       isSameETHAddress(stakingProvider, nuStakingProvider)
         ? BigNumber.from(
-            (await this._vendingMachines.nu.convertToT(nuStake)).tAmount
-          ).sub(BigNumber.from(nuInTStake))
+            (await this._vendingMachines.nu.convertToT(nuStake.toString()))
+              .tAmount
+          ).sub(BigNumber.from(nuInTStake.toString()))
         : ZERO
 
     const keepEligableStakeInT = (
-      await this._vendingMachines.keep.convertToT(eligibleKeepStake)
+      await this._vendingMachines.keep.convertToT(eligibleKeepStake.toString())
     ).tAmount
     const possibleKeepTopUpInT = BigNumber.from(keepEligableStakeInT).sub(
       BigNumber.from(keepInTStake)


### PR DESCRIPTION
Backport of: #440 

The `Multicall` service calls `decodeFunctionResult` under the hood which returns the result as a `Result` type from `ethers` lib. A Result is an array, so each value can be accessed as a positional argument. Additionally, if values are named, the identical object as its positional value can be accessed by its name. So if we call `eligibleStake` function using `Multicall` we can get the value as `result[0]` or `result.balance`. In the previous implementation, we passed the amount as `Result` type to the `convertToT` which caused an unexpected error. Also, we should pass amount as a string to the `convertToT` method from `VendingMachine` service.