### PR TITLE
[Backport] Switch 2nd track deposit verifier endpoint to `keep-prd` instance

### DIFF
--- a/src/utils/verifyDepositAddress.ts
+++ b/src/utils/verifyDepositAddress.ts
@@ -12,7 +12,7 @@ export const verifyDepositAddress = async (
   depositAddress: string,
   network: BitcoinNetwork
 ): Promise<VerificationOutcome> => {
-  const endpoint = `https://us-central1-keep-test-f3e0.cloudfunctions.net/verify-deposit-address`
+  const endpoint = `https://us-central1-keep-prd-210b.cloudfunctions.net/verify-deposit-address`
 
   const { depositor, blindingFactor, refundPublicKeyHash, refundLocktime } =
     deposit


### PR DESCRIPTION
Backport of: #450 

Refs: https://github.com/keep-network/pm/issues/33

We deployed the 2nd track verifier function in the `keep-prd` GCP project. This is now the default production instance so we are switching the dashboard to point it.