### PR TITLE
Bumb tbtc-v2.ts lib version to 1.1.0-dev.10

### DIFF
--- a/src/threshold-ts/types/index.ts
+++ b/src/threshold-ts/types/index.ts
@@ -32,7 +32,7 @@ export interface BitcoinConfig {
   /**
    * Credentials for electrum client
    */
-  credentials?: BitcoinClientCredentials
+  credentials?: BitcoinClientCredentials[]
 
   /**
    * Additional options that can be passed to bitcoin client

--- a/src/utils/getThresholdLib.ts
+++ b/src/utils/getThresholdLib.ts
@@ -19,13 +19,15 @@ function getBitcoinConfig(): BitcoinConfig {
   const shouldMockBitcoinClient =
     getEnvVariable(EnvVariable.MOCK_BITCOIN_CLIENT) === "true"
 
-  const credentials: BitcoinClientCredentials = {
-    host: getEnvVariable(EnvVariable.ELECTRUM_HOST),
-    port: +getEnvVariable(EnvVariable.ELECTRUM_PORT),
-    protocol: getEnvVariable(
-      EnvVariable.ELECTRUM_PROTOCOL
-    ) as BitcoinClientCredentials["protocol"],
-  }
+  const credentials: BitcoinClientCredentials[] = [
+    {
+      host: getEnvVariable(EnvVariable.ELECTRUM_HOST),
+      port: +getEnvVariable(EnvVariable.ELECTRUM_PORT),
+      protocol: getEnvVariable(
+        EnvVariable.ELECTRUM_PROTOCOL
+      ) as BitcoinClientCredentials["protocol"],
+    },
+  ]
 
   return {
     client: shouldMockBitcoinClient ? new MockBitcoinClient() : undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3445,17 +3445,6 @@
     "@openzeppelin/contracts-upgradeable" "^4.6.0"
     "@threshold-network/solidity-contracts" "1.3.0-dev.2"
 
-"@keep-network/ecdsa@development":
-  version "2.1.0-dev.6"
-  resolved "https://registry.npmjs.org/@keep-network/ecdsa/-/ecdsa-2.1.0-dev.6.tgz#ccc690f784b6e802a5b80b2dfb7127d96e548a25"
-  integrity sha512-1D74OPVzzxxVcG8za/niuxmwEdDc5R6KNuHsUvsFkcHNJE1UgQNw+QdrI+k3M2so6YrO4L5lP7vTvIvBDbEMNQ==
-  dependencies:
-    "@keep-network/random-beacon" "2.1.0-dev.5"
-    "@keep-network/sortition-pools" "^2.0.0-pre.16"
-    "@openzeppelin/contracts" "^4.6.0"
-    "@openzeppelin/contracts-upgradeable" "^4.6.0"
-    "@threshold-network/solidity-contracts" "1.3.0-dev.3"
-
 "@keep-network/keep-core@1.8.0-dev.5":
   version "1.8.0-dev.5"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-dev.5.tgz#8b4d08ec437f29c94723ee54fcf76456ba5408c3"
@@ -3552,22 +3541,23 @@
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@keep-network/tbtc-v2.ts@development":
-  version "1.1.0-dev.5"
-  resolved "https://registry.npmjs.org/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.1.0-dev.5.tgz#6d31c6d5160f4fb1ee46985fbe92f20a270dc806"
-  integrity sha512-1oUM/OEononzhhQGtvWlb2ofZeY0VRnQyNO5tFHnZ+7I7A/Lm6/9OFtugXpTgpBFJ41ZhusbzBxPaUbMGeAOYA==
+  version "1.1.0-dev.10"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.1.0-dev.10.tgz#3ae01471992db2bae2ad6c4642c1750a83860d6e"
+  integrity sha512-A1iap6BdXkr2gu6kcCdT2bt/HosxmjWewmmEqnxOfK0Y5YQBKY4tkJI1VC2El3ScqhyWVgnj0AMyZsygKUl37Q==
   dependencies:
-    "@keep-network/ecdsa" development
+    "@keep-network/ecdsa" "2.1.0-dev.6"
     "@keep-network/tbtc-v2" "1.0.3-dev.0"
     bcoin "git+https://github.com/keep-network/bcoin.git#5accd32c63e6025a0d35d67739c4a6e84095a1f8"
     bcrypto "git+https://github.com/bcoin-org/bcrypto.git#semver:~5.5.0"
     bufio "^1.0.6"
     electrum-client-js "git+https://github.com/keep-network/electrum-client-js.git#v0.1.1"
     ethers "^5.5.2"
+    p-timeout "^4.1.0"
     wif "2.0.6"
 
 "@keep-network/tbtc-v2@1.0.3-dev.0":
   version "1.0.3-dev.0"
-  resolved "https://registry.npmjs.org/@keep-network/tbtc-v2/-/tbtc-v2-1.0.3-dev.0.tgz#754eab80269ea5a616c92cb8c1f607ec21343e0b"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.0.3-dev.0.tgz#754eab80269ea5a616c92cb8c1f607ec21343e0b"
   integrity sha512-RqIFZvJtbLgmPZvPgamIJoTc5UsosrPE2g3879RqU4XqntezF4gr95FIuUFmicjRy0OPsjCupU2HplxlWfQfdw==
   dependencies:
     "@keep-network/bitcoin-spv-sol" "3.4.0-solc-0.8"
@@ -8842,14 +8832,9 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-"bsert@git+https://github.com/chjj/bsert.git#semver:~0.0.10":
+"bsert@git+https://github.com/chjj/bsert.git#semver:~0.0.10", bsert@~0.0.10:
   version "0.0.10"
   resolved "git+https://github.com/chjj/bsert.git#bd09d49eab8644bca08ae8259a3d8756e7d453fc"
-
-bsert@~0.0.10:
-  version "0.0.10"
-  resolved "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz#231ac82873a1418c6ade301ab5cd9ae385895597"
-  integrity sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==
 
 "bsock@git+https://github.com/bcoin-org/bsock.git#semver:~0.1.9", bsock@~0.1.8, bsock@~0.1.9:
   version "0.1.9"
@@ -8966,7 +8951,7 @@ bufferutil@^4.0.1:
 
 bufio@^1.0.6:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/bufio/-/bufio-1.2.0.tgz#b9ad1c06b0d9010363c387c39d2810a7086d143f"
+  resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.2.0.tgz#b9ad1c06b0d9010363c387c39d2810a7086d143f"
   integrity sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA==
 
 "bufio@git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6":
@@ -8975,7 +8960,7 @@ bufio@^1.0.6:
 
 bufio@~1.0.7:
   version "1.0.7"
-  resolved "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz#b7f63a1369a0829ed64cc14edf0573b3e382a33e"
+  resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.0.7.tgz#b7f63a1369a0829ed64cc14edf0573b3e382a33e"
   integrity sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==
 
 builtin-modules@^3.1.0:
@@ -16479,7 +16464,7 @@ loader-utils@^2.0.0:
 
 loady@~0.0.1, loady@~0.0.5:
   version "0.0.5"
-  resolved "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz#b17adb52d2fb7e743f107b0928ba0b591da5d881"
+  resolved "https://registry.yarnpkg.com/loady/-/loady-0.0.5.tgz#b17adb52d2fb7e743f107b0928ba0b591da5d881"
   integrity sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==
 
 locate-path@^2.0.0:
@@ -18171,6 +18156,11 @@ p-timeout@^3.1.0:
   integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
   dependencies:
     p-finally "^1.0.0"
+
+p-timeout@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-4.1.0.tgz#788253c0452ab0ffecf18a62dff94ff1bd09ca0a"
+  integrity sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==
 
 p-try@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Bump tbtc-v2.ts lib version from `1.1.0-dev.5` to `1.1.0-dev.10`.

There was a change in tbtc-v2.ts project (https://github.com/keep-network/tbtc-v2/pull/534) that added a possibility to define multiple URLs for electrum connection as fallbacks for connection problems. Here we wrap our credentials into array when getting bitcoin config from `getBitcoinConfig` method.