### PR TITLE
[Backport] Update unstake flow

### DIFF
--- a/src/components/Modal/TopupTModal/TopUpTModal.tsx
+++ b/src/components/Modal/TopupTModal/TopUpTModal.tsx
@@ -53,9 +53,13 @@ const TopupTModal: FC<
             <H5 mb={4} color={useColorModeValue("gray.800", "white")}>
               You are about to top up your stake
             </H5>
-            <BodyLg>
+            <BodyLg mb="6">
               By topping up your stake you will add a new deposit of tokens to
               your initial stake.
+            </BodyLg>
+            <BodyLg>
+              If you want to put your new topped-up tokens at work, make sure to
+              increase the authorization to your applications.
             </BodyLg>
           </InfoBox>
           <StakingStats

--- a/src/components/Modal/UnstakeTModal/DeauthorizeInfo.tsx
+++ b/src/components/Modal/UnstakeTModal/DeauthorizeInfo.tsx
@@ -1,0 +1,25 @@
+import { FC } from "react"
+import { BodyLg } from "@threshold-network/components"
+import ButtonLink from "../../ButtonLink"
+
+export const DeauthorizeInfo: FC<{ stakingProvider: string }> = ({
+  stakingProvider,
+}) => {
+  return (
+    <>
+      <BodyLg mt="6">
+        Make sure you deauthorized all the applications using your stake funds.
+      </BodyLg>
+
+      <ButtonLink
+        size="sm"
+        variant="outline"
+        to={`/staking/${stakingProvider}/authorize`}
+        alignSelf="flex-end"
+        mt="5"
+      >
+        Deauthorize Applications
+      </ButtonLink>
+    </>
+  )
+}

--- a/src/components/Modal/UnstakeTModal/Step1.tsx
+++ b/src/components/Modal/UnstakeTModal/Step1.tsx
@@ -1,5 +1,10 @@
 import { FC, useState, useMemo } from "react"
 import {
+  BodySm,
+  H5,
+  LabelSm,
+  LineDivider,
+  LineDividerCenterElement,
   Button,
   ModalBody,
   ModalFooter,
@@ -11,13 +16,7 @@ import {
   TabPanel,
   TabList,
   Tab,
-} from "@chakra-ui/react"
-import {
-  BodySm,
-  H5,
-  LabelSm,
-  LineDivider,
-  LineDividerCenterElement,
+  BodyLg,
 } from "@threshold-network/components"
 import InfoBox from "../../InfoBox"
 import { StakingContractLearnMore } from "../../Link"
@@ -29,6 +28,7 @@ import { BaseModalProps, UpgredableToken } from "../../../types"
 import { StakeData } from "../../../types/staking"
 import { ModalType, Token, UnstakeType } from "../../../enums"
 import withBaseModal from "../withBaseModal"
+import { DeauthorizeInfo } from "./DeauthorizeInfo"
 import ModalCloseButton from "../ModalCloseButton"
 
 const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
@@ -99,10 +99,11 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
               </UnorderedList>
             </>
           ) : (
-            <BodySm>
+            <BodyLg>
               You can partially or totally unstake depending on your needs.
-            </BodySm>
+            </BodyLg>
           )}
+          <DeauthorizeInfo stakingProvider={stake.stakingProvider} />
         </InfoBox>
         <Tabs isFitted>
           <TabList mb="8">

--- a/src/components/Modal/UnstakeTModal/Step1.tsx
+++ b/src/components/Modal/UnstakeTModal/Step1.tsx
@@ -32,6 +32,7 @@ import { DeauthorizeInfo } from "./DeauthorizeInfo"
 import { useAppSelector } from "../../../hooks/store"
 import { selectAvailableAmountToUnstakeByStakingProvider } from "../../../store/staking"
 import ModalCloseButton from "../ModalCloseButton"
+import { UnstakingFormLabel } from "../../UnstakingFormLabel"
 
 const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
   stake,
@@ -134,10 +135,16 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
             <TabPanel>
               <TokenAmountForm
                 onSubmitForm={onSubmitForm}
-                label="Unstake amount"
+                label={
+                  <UnstakingFormLabel
+                    maxTokenAmount={availableAmountToUnstake.t}
+                    stakingProvider={stake.stakingProvider}
+                    label="Unstake amount"
+                    hasAuthorizedApps={!availableAmountToUnstake.canUnstakeAll}
+                  />
+                }
                 submitButtonText="Unstake"
                 maxTokenAmount={availableAmountToUnstake.t}
-                shouldDisplayMaxAmountInLabel
               />
             </TabPanel>
             {hasKeepStake && (
@@ -145,7 +152,16 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
                 <TokenAmountForm
                   onSubmitForm={onSubmitForm}
                   initialTokenAmount={stake.keepInTStake}
-                  label="Unstake amount"
+                  label={
+                    <UnstakingFormLabel
+                      maxTokenAmount={availableAmountToUnstake.keepInT}
+                      stakingProvider={stake.stakingProvider}
+                      label="Unstake amount"
+                      hasAuthorizedApps={
+                        !availableAmountToUnstake.canUnstakeAll
+                      }
+                    />
+                  }
                   submitButtonText="Unstake"
                   maxTokenAmount={availableAmountToUnstake.keepInT}
                   icon={KeepCircleBrand}
@@ -158,11 +174,19 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
               <TabPanel>
                 <TokenAmountForm
                   onSubmitForm={onSubmitForm}
-                  label="Unstake amount"
+                  label={
+                    <UnstakingFormLabel
+                      maxTokenAmount={availableAmountToUnstake.nuInT}
+                      stakingProvider={stake.stakingProvider}
+                      label="Unstake amount"
+                      hasAuthorizedApps={
+                        !availableAmountToUnstake.canUnstakeAll
+                      }
+                    />
+                  }
                   submitButtonText="Unstake"
                   maxTokenAmount={availableAmountToUnstake.nuInT}
                   icon={NuCircleBrand}
-                  shouldDisplayMaxAmountInLabel
                 />
               </TabPanel>
             )}

--- a/src/components/Modal/UnstakeTModal/Step1.tsx
+++ b/src/components/Modal/UnstakeTModal/Step1.tsx
@@ -29,6 +29,8 @@ import { StakeData } from "../../../types/staking"
 import { ModalType, Token, UnstakeType } from "../../../enums"
 import withBaseModal from "../withBaseModal"
 import { DeauthorizeInfo } from "./DeauthorizeInfo"
+import { useAppSelector } from "../../../hooks/store"
+import { selectAvailableAmountToUnstakeByStakingProvider } from "../../../store/staking"
 import ModalCloseButton from "../ModalCloseButton"
 
 const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
@@ -67,6 +69,13 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
       hasNuStake && hasKeepStake ? "KEEP + NU" : hasKeepStake ? "KEEP" : "NU"
     return `Unstakes max of both native tokens and legacy tokens (${suffix} + T)`
   }, [hasNuStake, hasKeepStake])
+
+  const availableAmountToUnstake = useAppSelector((state) =>
+    selectAvailableAmountToUnstakeByStakingProvider(
+      state,
+      stake.stakingProvider
+    )
+  )
 
   return (
     <>
@@ -127,7 +136,7 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
                 onSubmitForm={onSubmitForm}
                 label="Unstake amount"
                 submitButtonText="Unstake"
-                maxTokenAmount={stake.tStake}
+                maxTokenAmount={availableAmountToUnstake.t}
                 shouldDisplayMaxAmountInLabel
               />
             </TabPanel>
@@ -138,7 +147,7 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
                   initialTokenAmount={stake.keepInTStake}
                   label="Unstake amount"
                   submitButtonText="Unstake"
-                  maxTokenAmount={stake.keepInTStake}
+                  maxTokenAmount={availableAmountToUnstake.keepInT}
                   icon={KeepCircleBrand}
                   helperText="The legacy tokens can be only unstaked in full amount"
                   isDisabled
@@ -151,7 +160,7 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
                   onSubmitForm={onSubmitForm}
                   label="Unstake amount"
                   submitButtonText="Unstake"
-                  maxTokenAmount={stake.nuInTStake}
+                  maxTokenAmount={availableAmountToUnstake.nuInT}
                   icon={NuCircleBrand}
                   shouldDisplayMaxAmountInLabel
                 />
@@ -166,7 +175,12 @@ const UnstakeTModal: FC<BaseModalProps & { stake: StakeData }> = ({
                 <LabelSm>OR</LabelSm>
               </LineDividerCenterElement>
             </LineDivider>
-            <Button variant="outline" isFullWidth onClick={onUnstakeAllBtn}>
+            <Button
+              variant="outline"
+              isFullWidth
+              onClick={onUnstakeAllBtn}
+              isDisabled={!availableAmountToUnstake.canUnstakeAll}
+            >
               Unstake All
             </Button>
             <BodySm mt="2">{unstakeAllBtnHelperText}</BodySm>

--- a/src/components/Modal/UnstakeTModal/Step2.tsx
+++ b/src/components/Modal/UnstakeTModal/Step2.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   AlertDescription,
   AlertIcon,
+  AlertTitle,
   Button,
   Divider,
   ModalBody,
@@ -10,8 +11,10 @@ import {
   ModalHeader,
   Stack,
   useColorModeValue,
-} from "@chakra-ui/react"
-import { BodyLg, H5 } from "@threshold-network/components"
+  BodyLg,
+  Box,
+  H5,
+} from "@threshold-network/components"
 import InfoBox from "../../InfoBox"
 import { StakingContractLearnMore } from "../../Link"
 import StakingStats from "../../StakingStats"
@@ -21,6 +24,7 @@ import { BaseModalProps } from "../../../types"
 import { StakeData } from "../../../types/staking"
 import { ModalType, UnstakeType } from "../../../enums"
 import withBaseModal from "../withBaseModal"
+import { DeauthorizeInfo } from "./DeauthorizeInfo"
 import ModalCloseButton from "../ModalCloseButton"
 
 const UnstakeTModal: FC<
@@ -80,6 +84,7 @@ const UnstakeTModal: FC<
             <BodyLg>
               You can partially or totally unstake depending on your needs.
             </BodyLg>
+            <DeauthorizeInfo stakingProvider={stake.stakingProvider} />
           </InfoBox>
           <StakingStats
             stakeAmount={_amountToUnstake}
@@ -89,13 +94,18 @@ const UnstakeTModal: FC<
             authorizer={stake.authorizer}
           />
           <Alert status="warning">
-            <AlertIcon alignSelf="center" />
-
-            <AlertDescription color={useColorModeValue("gray.700", "gray.300")}>
-              Take note! If you fully unstake you will not be able to use the
-              same Staking Provider Address for new stakes. This unstaked stake
-              can be topped up anytime you want.
-            </AlertDescription>
+            <AlertIcon />
+            <Box color={useColorModeValue("gray.700", "gray.300")}>
+              <AlertTitle>Take note!</AlertTitle>
+              <AlertDescription>
+                If you fully unstake you will not be able to use the same
+                Provider Address for new stakes.
+                <Box as="p" mt="5">
+                  A fully unstaked stake will be shown as an inactive stake and
+                  can be toppped up anytime in order to re-activate it.
+                </Box>
+              </AlertDescription>
+            </Box>
           </Alert>
         </Stack>
         <StakingContractLearnMore mt="10" />

--- a/src/components/UnstakingFormLabel/index.tsx
+++ b/src/components/UnstakingFormLabel/index.tsx
@@ -1,0 +1,57 @@
+import { FC } from "react"
+import { Box, BodySm } from "@threshold-network/components"
+import { TokenAmountFormBaseProps } from "../Forms/TokenAmountForm"
+import { formatTokenAmount } from "../../utils/formatAmount"
+import TooltipIcon from "../TooltipIcon"
+import Link from "../Link"
+
+type Props = Pick<
+  TokenAmountFormBaseProps,
+  "token" | "maxTokenAmount" | "label"
+> & { stakingProvider: string; hasAuthorizedApps: boolean }
+
+type TooltipLabelProps = Pick<Props, "stakingProvider">
+
+const TooltipLabel: FC<TooltipLabelProps> = ({ stakingProvider }) => {
+  return (
+    <>
+      If you want to unstake more T deauthorize the apps for this stake first{" "}
+      <Link to={`/staking/${stakingProvider}/authorize`}>here</Link>.
+    </>
+  )
+}
+
+export const UnstakingFormLabel: FC<Props> = ({
+  label = "Amount",
+  maxTokenAmount,
+  stakingProvider,
+  hasAuthorizedApps,
+  token = { decimals: 18, symbol: "T" },
+}) => {
+  return (
+    <>
+      <Box as="span">{label} </Box>
+      <BodySm
+        as="span"
+        float="right"
+        color="gray.500"
+        display="flex"
+        alignItems="center"
+        sx={{ ">span": { display: "flex" } }}
+      >
+        {maxTokenAmount
+          ? formatTokenAmount(maxTokenAmount, undefined, token.decimals)
+          : "--"}{" "}
+        {token.symbol}
+        {hasAuthorizedApps && (
+          <TooltipIcon
+            ml="0.25em"
+            width="1.25em"
+            height="1.25em"
+            label={<TooltipLabel stakingProvider={stakingProvider} />}
+          />
+        )}
+      </BodySm>
+    </>
+  )
+}

--- a/src/pages/Staking/StakeCard/index.tsx
+++ b/src/pages/Staking/StakeCard/index.tsx
@@ -35,6 +35,8 @@ import { StakeCardContext } from "../../../contexts/StakeCardContext"
 import { useStakeCardContext } from "../../../hooks/useStakeCardContext"
 import { isSameETHAddress } from "../../../threshold-ts/utils"
 import { useWeb3React } from "@web3-react/core"
+import { useAppSelector } from "../../../hooks/store"
+import { selectAvailableAmountToUnstakeByStakingProvider } from "../../../store/staking"
 
 const StakeCardProvider: FC<{ stake: StakeData }> = ({ stake }) => {
   const isInactiveStake = BigNumber.from(stake.totalInTStake).isZero()
@@ -68,6 +70,12 @@ const StakeCard: FC<{ stake: StakeData }> = ({ stake }) => {
   const { isInactiveStake, canTopUpKepp, canTopUpNu, isPRESet } =
     useStakeCardContext()
   const { account } = useWeb3React()
+  const availableAmountToUnstake = useAppSelector((state) =>
+    selectAvailableAmountToUnstakeByStakingProvider(
+      state,
+      stake.stakingProvider
+    )
+  )
 
   const isOwner = isSameETHAddress(account ?? AddressZero, stake.owner)
 
@@ -157,7 +165,7 @@ const StakeCard: FC<{ stake: StakeData }> = ({ stake }) => {
           onSubmitForm={onSubmitForm}
           label="Amount"
           submitButtonText={submitButtonText}
-          maxTokenAmount={isStakeAction ? tBalance : stake.tStake}
+          maxTokenAmount={isStakeAction ? tBalance : availableAmountToUnstake.t}
           shouldDisplayMaxAmountInLabel
           isDisabled={!isOwner}
           submitButtonVariant="outline"

--- a/src/pages/Staking/StakeCard/index.tsx
+++ b/src/pages/Staking/StakeCard/index.tsx
@@ -17,7 +17,6 @@ import { useTokenBalance } from "../../../hooks/useTokenBalance"
 import { useModal } from "../../../hooks/useModal"
 import { StakeData } from "../../../types/staking"
 import {
-  ExternalHref,
   ModalType,
   StakeType,
   Token,
@@ -37,6 +36,7 @@ import { isSameETHAddress } from "../../../threshold-ts/utils"
 import { useWeb3React } from "@web3-react/core"
 import { useAppSelector } from "../../../hooks/store"
 import { selectAvailableAmountToUnstakeByStakingProvider } from "../../../store/staking"
+import { UnstakingFormLabel } from "../../../components/UnstakingFormLabel"
 
 const StakeCardProvider: FC<{ stake: StakeData }> = ({ stake }) => {
   const isInactiveStake = BigNumber.from(stake.totalInTStake).isZero()
@@ -163,10 +163,20 @@ const StakeCard: FC<{ stake: StakeData }> = ({ stake }) => {
         <TokenAmountForm
           innerRef={formRef}
           onSubmitForm={onSubmitForm}
-          label="Amount"
+          label={
+            isStakeAction ? (
+              "Amount"
+            ) : (
+              <UnstakingFormLabel
+                maxTokenAmount={availableAmountToUnstake.t}
+                stakingProvider={stake.stakingProvider}
+                hasAuthorizedApps={!availableAmountToUnstake.canUnstakeAll}
+              />
+            )
+          }
           submitButtonText={submitButtonText}
           maxTokenAmount={isStakeAction ? tBalance : availableAmountToUnstake.t}
-          shouldDisplayMaxAmountInLabel
+          shouldDisplayMaxAmountInLabel={isStakeAction}
           isDisabled={!isOwner}
           submitButtonVariant="outline"
         />

--- a/src/store/staking/selectors.ts
+++ b/src/store/staking/selectors.ts
@@ -17,6 +17,24 @@ export const selectStakeByStakingProvider = createSelector(
     stakes.find((_) => isSameETHAddress(_.stakingProvider, stakingProvider))
 )
 
+// This selector returns available amount to unstake for T, KEEP and NU in T
+// denomination. The maximum unstake amount depends on the authorized apps for
+// example suppose the given staking provider has 10T, 20T worth of KEEP and 30
+// T worth of NU- all staked. The maximum application authorization is 40 T,
+// then the maximum available amount to unstake is:
+// - 10T from T stake because: 10T(T stake) - max(0, 40T(authorization) -
+//   20T(KEEP stake) - 30T(NU stake)) = 10,
+// - 20T from KEEP stake because: 20T(KEEP stake) - max(0, 40T(authorization) -
+//   30T(NU stake) - 10T(T stake)) = 20,
+// - 20T from NU stake because: 30T(NU stake) - max(0, 40T(authorization) -
+//   20T(KEEP stake) -10T(T stake)) = 20,
+// - An owner can't unstake all stake(KEEP+NU+T) because has authorized
+//   applications. To unstake all the staking provider cannot have any
+//   authorized apps.
+// In other words, the minimum stake amount for the specified stake type is the
+// minimum amount of stake of the given type needed to satisfy the maximum
+// application authorization given the staked amounts of the other stake types
+// for that staking provider.
 export const selectAvailableAmountToUnstakeByStakingProvider = createSelector(
   [
     (state: RootState, stakingProvider: string) =>

--- a/src/store/staking/selectors.ts
+++ b/src/store/staking/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit"
 import { BigNumber } from "ethers"
-import { max } from "../../threshold-ts/utils"
+import { ZERO, max } from "../../threshold-ts/utils"
 import { RootState } from ".."
 import { StakeData } from "../../types/staking"
 import { isSameETHAddress } from "../../web3/utils"
@@ -40,27 +40,25 @@ export const selectAvailableAmountToUnstakeByStakingProvider = createSelector(
       }
     }
 
-    const maxAuthorization = BigNumber.from(
-      max(
-        tbtcAppData.authorizedStake || "0",
-        randomBeaconAppData.authorizedStake || "0"
-      )
+    const maxAuthorization = max(
+      tbtcAppData.authorizedStake || ZERO,
+      randomBeaconAppData.authorizedStake || ZERO
     )
 
     const isZeroAuthorization = maxAuthorization.isZero()
 
     const nuInTMinStake = max(
-      "0",
+      ZERO,
       maxAuthorization.sub(stake.tStake).sub(stake.keepInTStake).toString()
     )
 
     const tMinStake = max(
-      "0",
+      ZERO,
       maxAuthorization.sub(stake.nuInTStake).sub(stake.keepInTStake).toString()
     )
 
-    const keepInT = max(
-      "0",
+    const keepInTMinStake = max(
+      ZERO,
       maxAuthorization.sub(stake.nuInTStake).sub(stake.tStake).toString()
     )
 
@@ -69,7 +67,7 @@ export const selectAvailableAmountToUnstakeByStakingProvider = createSelector(
         ? stake.nuInTStake
         : BigNumber.from(stake.nuInTStake).sub(nuInTMinStake).toString(),
       keepInT:
-        isZeroAuthorization || BigNumber.from(keepInT).isZero()
+        isZeroAuthorization || BigNumber.from(keepInTMinStake).isZero()
           ? stake.keepInTStake
           : "0",
       t: isZeroAuthorization

--- a/src/threshold-ts/utils/index.ts
+++ b/src/threshold-ts/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./address"
 export * from "./bitcoin"
 export * from "./constants"
+export * from "./math"
 export * from "./contract"

--- a/src/threshold-ts/utils/math.ts
+++ b/src/threshold-ts/utils/math.ts
@@ -1,0 +1,9 @@
+import { BigNumber } from "ethers"
+
+export const min = (a: string | number, b: string | number) => {
+  return BigNumber.from(a).lt(b) ? a.toString() : b.toString()
+}
+
+export const max = (a: string | number, b: string | number) => {
+  return BigNumber.from(a).gt(b) ? a.toString() : b.toString()
+}

--- a/src/threshold-ts/utils/math.ts
+++ b/src/threshold-ts/utils/math.ts
@@ -1,9 +1,20 @@
-import { BigNumber } from "ethers"
+import { BigNumber, BigNumberish } from "ethers"
 
-export const min = (a: string | number, b: string | number) => {
-  return BigNumber.from(a).lt(b) ? a.toString() : b.toString()
+const compare = (
+  a: BigNumberish,
+  b: BigNumberish,
+  nameOfCompareFunction: "lt" | "gt"
+) => {
+  const _a = BigNumber.from(a)
+  const _b = BigNumber.from(b)
+
+  return _a[nameOfCompareFunction](_b) ? _a : _b
 }
 
-export const max = (a: string | number, b: string | number) => {
-  return BigNumber.from(a).gt(b) ? a.toString() : b.toString()
+export const min = (a: BigNumberish, b: BigNumberish) => {
+  return compare(a, b, "lt")
+}
+
+export const max = (a: BigNumberish, b: BigNumberish) => {
+  return compare(a, b, "gt")
 }


### PR DESCRIPTION
Backport of: #336

This PR updates the unstake flow. The maximum unstake amount depends on the authorized apps for example suppose the given staking provider has 10T, 20T worth of KEEP and 30 T worth of NU- all staked. The maximum application authorization is 40 T, then the maximum available amount to unstake is:
- 10T from T stake because: `10T(T stake) - max(0, 40T(authorization) - 20T(KEEP stake) - 30T(NU stake)) = 10`,
- 20T from KEEP stake because: `20T(KEEP stake) - max(0, 40T(authorization) - 30T(NU stake) - 10T(T stake)) = 20`,
- 20T from NU stake because: `30T(NU stake) - max(0, 40T(authorization) - 20T(KEEP stake) -10T(T stake)) = 20`,
- An owner can't unstake all stake(KEEP+NU+T) because has authorized applications. To unstake all the staking provider cannot have any authorized apps.

Here we also update a copy in the unstaking and top-up modals and add a tooltip next to the max amount to unstake(in unstake form) that says the given staking provider has authorized apps and must deauthorize first if they want to unstake more T.

<details>
  <summary>Screenshots</summary>

![obraz](https://user-images.githubusercontent.com/57687279/219072237-01241dfb-52cd-44a4-b196-ec18f201fc86.png)

</details>