### PR TITLE
Improve sentry breadcrumb messages for ui.click event

### DIFF
--- a/src/sentry/index.ts
+++ b/src/sentry/index.ts
@@ -11,6 +11,41 @@ export const init = () => {
     dsn: dsn,
     integrations: [new BrowserTracing()],
     tracesSampleRate: 0.5,
+    beforeBreadcrumb(breadcrumb, hint) {
+      if (breadcrumb.category === "ui.click") {
+        console.log("BREADCRUMB: ", breadcrumb)
+        console.log("HINT: ", hint)
+        const { target } = hint?.event
+        let buttonName: string
+        let buttonURI: string
+        let buttonClass: string
+        if (
+          target?.firstChild?.data &&
+          typeof target?.firstChild?.data === "string"
+        ) {
+          buttonName = target.firstChild.data
+        } else if (target?.ariaLabel && typeof target?.ariaLabel === "string") {
+          buttonName = target.ariaLabel
+        }
+        if (target?.baseURI && typeof target?.baseURI === "string") {
+          buttonURI = target.baseURI
+        }
+        if (target?.className) {
+          buttonClass = target.classList.toString()
+        }
+        const button = {
+          name: buttonName!,
+          url: buttonURI!,
+          class: buttonClass!,
+        }
+        console.log("Clicked button: ")
+        console.log("name: ", button.name)
+        console.log("url: ", button.url)
+        console.log("buttonClass: ", button.class)
+        breadcrumb.message = `Button name: ${button.name}; Url: ${button.url}; Class: ${button.class}`
+      }
+      return breadcrumb
+    },
   })
 }
 

--- a/src/sentry/index.ts
+++ b/src/sentry/index.ts
@@ -14,13 +14,6 @@ interface SentryUIElement {
 
 export const init = () => {
   const dsn = getEnvVariable(EnvVariable.SENTRY_DSN)
-  const element: SentryUIElement = {
-    name: undefined,
-    type: undefined,
-    url: undefined,
-    class: undefined,
-    id: undefined,
-  }
 
   Sentry.init({
     dsn: dsn,
@@ -28,6 +21,13 @@ export const init = () => {
     tracesSampleRate: 0.5,
     beforeBreadcrumb(breadcrumb, hint) {
       if (breadcrumb.category === "ui.click") {
+        const element: SentryUIElement = {
+          name: undefined,
+          type: undefined,
+          url: undefined,
+          class: undefined,
+          id: undefined,
+        }
         const { target } = hint?.event
 
         if (target) {

--- a/src/sentry/index.ts
+++ b/src/sentry/index.ts
@@ -4,8 +4,23 @@ import { getEnvVariable } from "../utils/getEnvVariable"
 import { EnvVariable } from "../enums"
 import { Primitive } from "@sentry/types"
 
+interface SentryUIElement {
+  name: string | undefined
+  type: string | undefined
+  url: string | undefined
+  class: string | undefined
+  id: string | undefined
+}
+
 export const init = () => {
   const dsn = getEnvVariable(EnvVariable.SENTRY_DSN)
+  const element: SentryUIElement = {
+    name: undefined,
+    type: undefined,
+    url: undefined,
+    class: undefined,
+    id: undefined,
+  }
 
   Sentry.init({
     dsn: dsn,
@@ -13,36 +28,24 @@ export const init = () => {
     tracesSampleRate: 0.5,
     beforeBreadcrumb(breadcrumb, hint) {
       if (breadcrumb.category === "ui.click") {
-        console.log("BREADCRUMB: ", breadcrumb)
-        console.log("HINT: ", hint)
         const { target } = hint?.event
-        let buttonName: string
-        let buttonURI: string
-        let buttonClass: string
-        if (
-          target?.firstChild?.data &&
-          typeof target?.firstChild?.data === "string"
-        ) {
-          buttonName = target.firstChild.data
-        } else if (target?.ariaLabel && typeof target?.ariaLabel === "string") {
-          buttonName = target.ariaLabel
+
+        if (target) {
+          if (
+            target.firstChild?.data &&
+            typeof target?.firstChild?.data === "string"
+          ) {
+            element.name = target.firstChild.data
+          } else if (target.ariaLabel && typeof target.ariaLabel === "string") {
+            element.name = target.ariaLabel
+          }
+          element.url = target.baseURI || undefined
+          element.type = target.localName ? `<${target.localName}>` : undefined
+          element.class = target.classList?.toString() || undefined
+          element.id = target.id || undefined
         }
-        if (target?.baseURI && typeof target?.baseURI === "string") {
-          buttonURI = target.baseURI
-        }
-        if (target?.className) {
-          buttonClass = target.classList.toString()
-        }
-        const button = {
-          name: buttonName!,
-          url: buttonURI!,
-          class: buttonClass!,
-        }
-        console.log("Clicked button: ")
-        console.log("name: ", button.name)
-        console.log("url: ", button.url)
-        console.log("buttonClass: ", button.class)
-        breadcrumb.message = `Button name: ${button.name}; Url: ${button.url}; Class: ${button.class}`
+
+        breadcrumb.message = `Element name: ${element.name}; Type: ${element.type}; Url: ${element.url}; Class: ${element.class}; Id: ${element.id}`
       }
       return breadcrumb
     },


### PR DESCRIPTION
# The problem

While debugging (or actually trying to debug) the issues that sentry has catched in our app I've encoutered a lot of problems with figuring out what is the exact issue and it was even more problematic to reproduce the error. I think that one source of that problem was not very readable `Breadcrumbs` for `ui.click` events. It only displayed the `className` of the element clicked by the user and that doesn't say us anything useful because these classes are generated randomly by `chakra-ui`.

Here are the examples of how the `ui.click` event look like in Sentry from one of the generated deposit issues:
<img width="580" alt="image" src="https://user-images.githubusercontent.com/40306834/224295928-dd5e46eb-f0d6-4cbb-a104-6189a5a81028.png">
<img width="808" alt="image" src="https://user-images.githubusercontent.com/40306834/224296878-2b8cbb66-eed5-4d18-9137-a4678f0bbb1f.png">
<img width="697" alt="image" src="https://user-images.githubusercontent.com/40306834/224296917-43f5f184-eb5d-423e-a9df-958e1489961c.png">


As you can see there is no easy way to find out what exact button or element was clicked. We don't have those class names in our codebase so figuring out which element was clicked here is a tough nut to crack.

# The solution

I've decided to write some improvements that makes the `ui.click` events more readable. Here is an example of how it would look like after my changes:
<img width="951" alt="image" src="https://user-images.githubusercontent.com/40306834/224300153-0696261a-e351-43e6-a8ce-969ef679b08c.png">
<img width="951" alt="image" src="https://user-images.githubusercontent.com/40306834/224300116-e7104dde-f92e-41bc-80f5-f2ce74167623.png">


From these examples we can clearly see that the user clicked the input with the id `btcRecoveryAddress` and then clicked `Generate Deposit Address` button. This way it will be easier to reproduce the error.

### Changes

I've added [beforeBreadcrumbs](https://docs.sentry.io/platforms/javascript/enriching-events/breadcrumbs/#customize-breadcrumbs) function to the config object that we are passing to `Sentry.init()`. Thanks to that we can modify how the `breadcrumbs` in the Sentry website will look like. I'm checking if the specific breadcrum is an `ui.click` event by using the if statement:
```
if (breadcrumb.category === "ui.click")
```
and the modify the message with some useful data.