### PR TITLE
Improve readability on BTC recovery address

### DIFF
--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -32,7 +32,8 @@ type ComponentProps = {
   formId: string
 }
 
-const resolvedBTCAddressPrefix = supportedChainId === "1" ? "bc" : "t"
+const resolvedBTCAddressPrefix =
+  supportedChainId === "1" ? `"1" or "bc1"` : `"m", "n" or "tb1"`
 
 const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
   formId,
@@ -50,8 +51,8 @@ const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
       <FormikInput
         name="btcRecoveryAddress"
         label="BTC Recovery Address"
-        tooltip={`This address needs to start with the letters "${resolvedBTCAddressPrefix}". Recovery Address is a BTC address where your BTC funds are sent back if something exceptional happens with your deposit. A Recovery Address cannot be a multi-sig or an exchange address. Funds claiming is done by using the JSON file`}
-        placeholder={`BTC Address should start with “${resolvedBTCAddressPrefix}”`}
+        tooltip={`This address needs to start with ${resolvedBTCAddressPrefix}. Recovery Address is a BTC address where your BTC funds are sent back if something exceptional happens with your deposit. A Recovery Address cannot be a multi-sig or an exchange address. Funds claiming is done by using the JSON file`}
+        placeholder={`BTC Address should start with ${resolvedBTCAddressPrefix}`}
       />
     </Form>
   )

--- a/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/ProvideData.tsx
@@ -20,6 +20,7 @@ import { useTBTCDepositDataFromLocalStorage } from "../../../../hooks/tbtc"
 import withOnlyConnectedWallet from "../../../../components/withOnlyConnectedWallet"
 import { useDepositTelemetry } from "../../../../hooks/tbtc/useDepositTelemetry"
 import { isSameETHAddress } from "../../../../web3/utils"
+import { supportedChainId } from "../../../../utils/getEnvVariable"
 
 export interface FormValues {
   ethAddress: string
@@ -31,6 +32,8 @@ type ComponentProps = {
   formId: string
 }
 
+const resolvedBTCAddressPrefix = supportedChainId === "1" ? "bc" : "t"
+
 const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
   formId,
 }) => {
@@ -39,6 +42,7 @@ const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
       <FormikInput
         name="ethAddress"
         label="ETH Address"
+        placeholder="Address where you'll receive your tBTC"
         tooltip="ETH address is prepopulated with your wallet address. This is the address where you'll receive your tBTC."
         mb={6}
         isReadOnly={true}
@@ -46,7 +50,8 @@ const MintingProcessFormBase: FC<ComponentProps & FormikProps<FormValues>> = ({
       <FormikInput
         name="btcRecoveryAddress"
         label="BTC Recovery Address"
-        tooltip="Recovery Address is a BTC address where your BTC funds are sent back if something exceptional happens with your deposit. A Recovery Address cannot be a multi-sig or an exchange address. Funds claiming is done by using the JSON file."
+        tooltip={`This address needs to start with the letters "${resolvedBTCAddressPrefix}". Recovery Address is a BTC address where your BTC funds are sent back if something exceptional happens with your deposit. A Recovery Address cannot be a multi-sig or an exchange address. Funds claiming is done by using the JSON file`}
+        placeholder={`BTC Address should start with “${resolvedBTCAddressPrefix}”`}
       />
     </Form>
   )

--- a/src/pages/tBTC/HowItWorks/MintingTimelineCard.tsx
+++ b/src/pages/tBTC/HowItWorks/MintingTimelineCard.tsx
@@ -6,7 +6,7 @@ import {
   BoxLabel,
   List,
   ListItem,
-  ListIcon,
+  ListIcon as TListIcon,
 } from "@threshold-network/components"
 import { BsFillArrowRightCircleFill } from "react-icons/all"
 import {
@@ -16,6 +16,16 @@ import {
 } from "../Bridge/MintingCard/MintingTimeline"
 import Link from "../../../components/Link"
 import { ExternalHref } from "../../../enums"
+
+const ListIcon: FC = () => (
+  <TListIcon
+    color="brand.500"
+    verticalAlign="sub"
+    as={BsFillArrowRightCircleFill}
+    w="16px"
+    h="16px"
+  />
+)
 
 export const MintingTimelineCard: FC<ComponentProps<typeof Card>> = ({
   ...props
@@ -29,13 +39,7 @@ export const MintingTimelineCard: FC<ComponentProps<typeof Card>> = ({
       </BoxLabel>
       <List>
         <ListItem>
-          <ListIcon
-            color="brand.500"
-            verticalAlign="sub"
-            as={BsFillArrowRightCircleFill}
-            w="16px"
-            h="16px"
-          />
+          <ListIcon />
           <BodyMd as="span">
             This is where your tBTC (ERC20) will be sent after minting
             initiation.
@@ -47,13 +51,7 @@ export const MintingTimelineCard: FC<ComponentProps<typeof Card>> = ({
       </BoxLabel>
       <List mb="1.5rem" spacing="4">
         <ListItem>
-          <ListIcon
-            verticalAlign="sub"
-            color="brand.500"
-            as={BsFillArrowRightCircleFill}
-            w="16px"
-            h="16px"
-          />
+          <ListIcon />
           <BodyMd as="span">
             Providing a BTC refund address means your bitcoin will be safe, even
             in the unlikely case of an error minting.{" "}
@@ -63,17 +61,22 @@ export const MintingTimelineCard: FC<ComponentProps<typeof Card>> = ({
           </BodyMd>
         </ListItem>
         <ListItem>
-          <ListIcon
-            verticalAlign="sub"
-            color="brand.500"
-            as={BsFillArrowRightCircleFill}
-            w="16px"
-            h="16px"
-          />
+          <ListIcon />
           <BodyMd as="span">
             Make sure you provide a single BTC recovery address that you
             control. Don't use a multi-sig or an exchange address. You can read
             more about the requirements and P2PKH.{" "}
+            <Link isExternal href={ExternalHref.btcRecoveryAddress}>
+              Read more
+            </Link>
+          </BodyMd>
+        </ListItem>
+        <ListItem>
+          <ListIcon />
+          <BodyMd as="span">
+            This address has to start with the letters “bc” for Bitcoin Mainnet
+            and with the letter “t” for Testnet Bitcoin. This means that your
+            addresses are P2PKH or P2WPKH compliant.{" "}
             <Link isExternal href={ExternalHref.btcRecoveryAddress}>
               Read more
             </Link>

--- a/src/pages/tBTC/HowItWorks/MintingTimelineCard.tsx
+++ b/src/pages/tBTC/HowItWorks/MintingTimelineCard.tsx
@@ -74,8 +74,8 @@ export const MintingTimelineCard: FC<ComponentProps<typeof Card>> = ({
         <ListItem>
           <ListIcon />
           <BodyMd as="span">
-            This address has to start with the letters “bc” for Bitcoin Mainnet
-            and with the letter “t” for Testnet Bitcoin. This means that your
+            This address has to start with “1” or “bc1” for Bitcoin Mainnet and
+            with “n”, “m” or “tb1” for Testnet Bitcoin. This means that your
             addresses are P2PKH or P2WPKH compliant.{" "}
             <Link isExternal href={ExternalHref.btcRecoveryAddress}>
               Read more

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -88,8 +88,8 @@ export const validateBTCAddress = (
     !isValidBtcAddress(address, network) ||
     !isPublicKeyHashTypeAddress(address)
   ) {
-    return `The BTC Recovery address has to start with the letters "${
-      network === Network.mainnet ? "bc" : "t"
-    }", meaning it is P2PKH or P2WPKH compliant.`
+    return `The BTC Recovery address has to start with ${
+      network === Network.mainnet ? `"1" or "bc1"` : `"m", "n" or "tb1"`
+    }, meaning it is P2PKH or P2WPKH compliant.`
   }
 }

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -84,9 +84,12 @@ export const validateBTCAddress = (
 ) => {
   if (!address) {
     return "Required."
-  } else if (!isValidBtcAddress(address, network)) {
-    return "Invalid btc address."
-  } else if (!isPublicKeyHashTypeAddress(address)) {
-    return "Must be a P2PKH or P2WPKH address."
+  } else if (
+    !isValidBtcAddress(address, network) ||
+    !isPublicKeyHashTypeAddress(address)
+  ) {
+    return `The BTC Recovery address has to start with the letters "${
+      network === Network.mainnet ? "bc" : "t"
+    }", meaning it is P2PKH or P2WPKH compliant.`
   }
 }


### PR DESCRIPTION
Closes: #436

BTC Recovery Addresses need to be P2PKH or P2WPKH - this is a clunky and technical explanation both in the error message and on the How it Works page.