### PR TITLE
Visibility of tBTC system- QA fixes

### DIFF
--- a/src/pages/tBTC/Bridge/DepositDetails.tsx
+++ b/src/pages/tBTC/Bridge/DepositDetails.tsx
@@ -206,7 +206,7 @@ export const DepositDetails: PageComponent = () => {
             >
               <Box mb="8" w={{ base: "100%", xl: "65%" }}>
                 <TbtcMintingCardTitle />
-                <Flex mb="4" alignItems="center">
+                <Flex mb="4" alignItems="center" textStyle="bodyLg">
                   <BodyLg>
                     <Box as="span" fontWeight="600" color="brand.500">
                       {inProgressStep === "completed" ? "Minted" : "Minting"}

--- a/src/pages/tBTC/Bridge/DepositDetails.tsx
+++ b/src/pages/tBTC/Bridge/DepositDetails.tsx
@@ -230,7 +230,9 @@ export const DepositDetails: PageComponent = () => {
                 mb={{ base: "20", xl: "unset" }}
                 direction="column"
               >
-                <LabelSm mb="8">Transaction History</LabelSm>
+                <LabelSm mb="8" mt={{ xl: 2 }}>
+                  Transaction History
+                </LabelSm>
                 <Badge
                   size="sm"
                   colorScheme="yellow"

--- a/src/pages/tBTC/Bridge/DepositDetails.tsx
+++ b/src/pages/tBTC/Bridge/DepositDetails.tsx
@@ -201,10 +201,9 @@ export const DepositDetails: PageComponent = () => {
                 xl: "row",
               }}
               divider={<StackDivider />}
-              h="100%"
               spacing={4}
             >
-              <Box mb="8" w={{ base: "100%", xl: "65%" }}>
+              <Flex flexDirection="column" w={{ base: "100%", xl: "65%" }}>
                 <TbtcMintingCardTitle />
                 <Flex mb="4" alignItems="center" textStyle="bodyLg">
                   <BodyLg>
@@ -226,7 +225,7 @@ export const DepositDetails: PageComponent = () => {
                   inProgressStep={inProgressStep}
                 />
                 <StepSwitcher />
-              </Box>
+              </Flex>
               <Flex
                 w={{ base: "100%", xl: "35%" }}
                 mb={{ base: "20", xl: "unset" }}
@@ -532,7 +531,7 @@ const StepSwitcher: FC = () => {
           <BodyMd mt="8">
             Add the tBTC <TBTCTokenContractLink /> to your Ethereum wallet.
           </BodyMd>
-          <ButtonLink size="lg" mt="12" to="/tBTC" isFullWidth>
+          <ButtonLink size="lg" mt="12" mb="8" to="/tBTC" isFullWidth>
             New mint
           </ButtonLink>
         </>

--- a/src/pages/tBTC/Bridge/DepositDetails.tsx
+++ b/src/pages/tBTC/Bridge/DepositDetails.tsx
@@ -28,6 +28,8 @@ import {
   SkeletonText,
   SkeletonCircle,
   Image,
+  BodySm,
+  BodyXs,
 } from "@threshold-network/components"
 import { IoCheckmarkSharp, IoTime as TimeIcon } from "react-icons/all"
 import { InlineTokenBalance } from "../../../components/TokenBalance"
@@ -204,7 +206,7 @@ export const DepositDetails: PageComponent = () => {
             >
               <Box mb="8" w={{ base: "100%", xl: "65%" }}>
                 <TbtcMintingCardTitle />
-                <Flex mb="4">
+                <Flex mb="4" alignItems="center">
                   <BodyLg>
                     <Box as="span" fontWeight="600" color="brand.500">
                       {inProgressStep === "completed" ? "Minted" : "Minting"}
@@ -249,14 +251,16 @@ export const DepositDetails: PageComponent = () => {
                     .filter((item) => !!item.txHash)
                     .map((item) => (
                       <ListItem key={item.txHash}>
-                        {item.label}{" "}
-                        <ViewInBlockExplorer
-                          id={item.txHash!}
-                          type={ExplorerDataType.TRANSACTION}
-                          chain={item.chain}
-                          text="transaction"
-                        />
-                        .
+                        <BodySm>
+                          {item.label}{" "}
+                          <ViewInBlockExplorer
+                            id={item.txHash!}
+                            type={ExplorerDataType.TRANSACTION}
+                            chain={item.chain}
+                            text="transaction"
+                          />
+                          .
+                        </BodySm>
                       </ListItem>
                     ))}
                 </List>
@@ -277,15 +281,15 @@ export const DepositDetails: PageComponent = () => {
             {inProgressStep !== "completed" && (
               <>
                 <Divider />
-                <HStack mt="8" spacing="16" alignItems="center">
+                <Flex mt="8" alignItems="center">
                   <BodyLg>
                     Eager to start a new mint while waiting for this one? You
                     can now.
                   </BodyLg>
-                  <ButtonLink size="lg" to="/tBTC/mint">
+                  <ButtonLink size="lg" to="/tBTC/mint" marginLeft="auto">
                     New Mint
                   </ButtonLink>
-                </HStack>
+                </Flex>
               </>
             )}
           </>
@@ -363,22 +367,22 @@ type DepositDetailsTimelineItem = {
 const depositTimelineItems: DepositDetailsTimelineItem[] = [
   {
     id: "bitcoin-confirmations",
-    text: "Bitcoin Checkpoint",
+    text: `Bitcoin\nCheckpoint`,
     status: "semi-active",
   },
   {
     id: "minting-initialized",
-    text: "Minting Initialized",
+    text: "Minting\nInitialized",
     status: "inactive",
   },
   {
     id: "guardian-check",
-    text: "Guardian Check",
+    text: "Guardian\nCheck",
     status: "inactive",
   },
   {
     id: "minting-completed",
-    text: "Minting Completed",
+    text: "Minting\nCompleted",
     status: "inactive",
   },
 ]
@@ -429,7 +433,9 @@ const DepositDetailsTimeline: FC<DepositDetailsTimelineProps> = ({
             </TimelineDot>
             <TimelineConnector />
           </TimelineBreakpoint>
-          <TimelineContent>{item.text}</TimelineContent>
+          <TimelineContent>
+            <BodyXs whiteSpace="pre-line">{item.text}</BodyXs>
+          </TimelineContent>
         </TimelineItem>
       ))}
     </Timeline>

--- a/src/pages/tBTC/Bridge/DepositDetails.tsx
+++ b/src/pages/tBTC/Bridge/DepositDetails.tsx
@@ -84,7 +84,7 @@ export const DepositDetails: PageComponent = () => {
     CurveFactoryPoolId.TBTC_WBTC_SBTC
   )
 
-  const [inProgressStep, setInProgressStep] =
+  const [mintingProgressStep, setMintingProgressStep] =
     useState<DepositDetailsTimelineStep>("bitcoin-confirmations")
   const { mintingRequestedTxHash, mintingFinalizedTxHash } =
     useSubscribeToOptimisticMintingEvents(depositKey)
@@ -132,8 +132,8 @@ export const DepositDetails: PageComponent = () => {
     if (!confirmations || !requiredConfirmations || shouldStartFromFirstStep)
       return
 
-    setInProgressStep(
-      getInProgressStep({
+    setMintingProgressStep(
+      getMintingProgressStep({
         confirmations,
         requiredConfirmations,
         optimisticMintingFinalizedTxHash,
@@ -168,7 +168,7 @@ export const DepositDetails: PageComponent = () => {
   ]
 
   const mainCardProps =
-    inProgressStep === "completed"
+    mintingProgressStep === "completed"
       ? {
           backgroundImage: mainCardBackground,
           backgroundPosition: "bottom -10px right",
@@ -179,8 +179,8 @@ export const DepositDetails: PageComponent = () => {
   return (
     <DepositDetailsPageContext.Provider
       value={{
-        step: inProgressStep,
-        updateStep: setInProgressStep,
+        step: mintingProgressStep,
+        updateStep: setMintingProgressStep,
         btcTxHash: btcDepositTxHash,
         optimisticMintingRequestedTxHash:
           optimisticMintingRequestedTxHash ?? mintingRequestedTxHash,
@@ -208,9 +208,11 @@ export const DepositDetails: PageComponent = () => {
                 <Flex mb="4" alignItems="center" textStyle="bodyLg">
                   <BodyLg>
                     <Box as="span" fontWeight="600" color="brand.500">
-                      {inProgressStep === "completed" ? "Minted" : "Minting"}
+                      {mintingProgressStep === "completed"
+                        ? "Minted"
+                        : "Minting"}
                     </Box>
-                    {inProgressStep !== "completed" && ` - In progress...`}
+                    {mintingProgressStep !== "completed" && ` - In progress...`}
                   </BodyLg>{" "}
                   <InlineTokenBalance
                     tokenAmount={amount || "0"}
@@ -222,7 +224,7 @@ export const DepositDetails: PageComponent = () => {
                 </Flex>
                 <DepositDetailsTimeline
                   // isCompleted
-                  inProgressStep={inProgressStep}
+                  inProgressStep={mintingProgressStep}
                 />
                 <StepSwitcher />
               </Flex>
@@ -263,7 +265,7 @@ export const DepositDetails: PageComponent = () => {
                       </ListItem>
                     ))}
                 </List>
-                {inProgressStep !== "completed" && (
+                {mintingProgressStep !== "completed" && (
                   <>
                     <HStack spacing="4" mt="auto" mb="10" alignSelf="center">
                       <Image src={BitcoinIcon} />
@@ -271,13 +273,13 @@ export const DepositDetails: PageComponent = () => {
                       <Image src={tBTCIcon} />
                     </HStack>
                     <MintingProcessResource
-                      {...stepToResourceData[inProgressStep]}
+                      {...stepToResourceData[mintingProgressStep]}
                     />
                   </>
                 )}
               </Flex>
             </Stack>
-            {inProgressStep !== "completed" && (
+            {mintingProgressStep !== "completed" && (
               <>
                 <Divider />
                 <Flex mt="8" alignItems="center">
@@ -294,7 +296,7 @@ export const DepositDetails: PageComponent = () => {
           </>
         )}
       </Card>
-      {inProgressStep === "completed" && (
+      {mintingProgressStep === "completed" && (
         <ExternalPool
           title={"tBTC Curve Pool"}
           externalPoolData={{ ...tBTCWBTCSBTCPoolData }}
@@ -441,7 +443,7 @@ const DepositDetailsTimeline: FC<DepositDetailsTimelineProps> = ({
   )
 }
 
-const getInProgressStep = (
+const getMintingProgressStep = (
   depositDetails?: Omit<
     DepositData,
     "depositRevealedTxHash" | "btcTxHash" | "amount"

--- a/src/pages/tBTC/Bridge/MintUnmintNav.tsx
+++ b/src/pages/tBTC/Bridge/MintUnmintNav.tsx
@@ -15,6 +15,8 @@ const renderNavItem = (page: PageComponent, index: number) => (
     as={Link}
     to={page.route.path}
     tabId={index.toString()}
+    textDecoration="none"
+    _groupHover={{ textDecoration: "none" }}
   >
     {page.route.title}
   </FilterTab>

--- a/src/pages/tBTC/Bridge/MintingCard/MintingSuccess.tsx
+++ b/src/pages/tBTC/Bridge/MintingCard/MintingSuccess.tsx
@@ -1,12 +1,14 @@
-import { FC } from "react"
+import { FC, useEffect } from "react"
 import { useTbtcState } from "../../../../hooks/useTbtcState"
 import withOnlyConnectedWallet from "../../../../components/withOnlyConnectedWallet"
 import { useThreshold } from "../../../../contexts/ThresholdContext"
 import { Navigate } from "react-router"
+import { useRemoveDepositData } from "../../../../hooks/tbtc/useRemoveDepositData"
 
 const MintingSuccessComponent: FC = () => {
   const threshold = useThreshold()
   const { utxo } = useTbtcState()
+  const removeDepositData = useRemoveDepositData()
 
   const btcDepositTxHash = utxo.transactionHash.toString()
   const depositKey = threshold.tbtc.buildDepositKey(
@@ -15,7 +17,17 @@ const MintingSuccessComponent: FC = () => {
     "big-endian"
   )
 
-  return <Navigate to={`/tBTC/mint/deposit/${depositKey}`} />
+  useEffect(() => {
+    removeDepositData()
+  }, [removeDepositData])
+
+  return (
+    <Navigate
+      to={`/tBTC/mint/deposit/${depositKey}`}
+      state={{ shouldStartFromFirstStep: true }}
+      replace={true}
+    />
+  )
 }
 
 export const MintingSuccess = withOnlyConnectedWallet(MintingSuccessComponent)

--- a/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
+++ b/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
@@ -190,7 +190,7 @@ export const Step2: FC<CommonStepProps> = ({ txHash, onComplete }) => {
       subtitle={
         <>
           <BodyMd mb="9">
-            A Minter is assessing the minting initialization.If all is well, the
+            A Minter is assessing the minting initialization. If all is well, the
             Minter will transfer the initialization to the Guardian.
           </BodyMd>
           <BodyMd>

--- a/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
+++ b/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
@@ -8,16 +8,20 @@ import {
   Flex,
   HStack,
   Skeleton,
-  Icon,
   Box,
 } from "@threshold-network/components"
 import { CheckCircleIcon } from "@chakra-ui/icons"
-import { IoCheckmarkSharp } from "react-icons/all"
 import ViewInBlockExplorer, {
   Chain as ViewInBlockExplorerChain,
 } from "../../../../components/ViewInBlockExplorer"
 import { ExplorerDataType } from "../../../../utils/createEtherscanLink"
 import { ONE_SEC_IN_MILISECONDS } from "../../../../utils/date"
+import {
+  BTCConfirmationsIcon,
+  GuardianCheckIcon,
+  MintingCompletedIcon,
+  MintingInitializedIcon,
+} from "./DepositDetailsStepIcons"
 
 type StepTemplateProps = {
   title: string
@@ -31,6 +35,7 @@ type StepTemplateProps = {
   isIndeterminate?: boolean
   progressBarValue?: number
   progressBarMaxValue?: number
+  icon: JSX.Element
 }
 
 export const StepTemplate: FC<StepTemplateProps> = ({
@@ -45,6 +50,7 @@ export const StepTemplate: FC<StepTemplateProps> = ({
   isIndeterminate,
   isCompleted,
   onComplete,
+  icon,
 }) => {
   useEffect(() => {
     if (!isCompleted) return
@@ -57,7 +63,7 @@ export const StepTemplate: FC<StepTemplateProps> = ({
   }, [isCompleted, onComplete])
 
   return (
-    <Flex flexDirection="column" alignItems="center">
+    <Flex flexDirection="column" alignItems="center" height="100%">
       <BodyLg
         color="gray.700"
         mt="8"
@@ -80,22 +86,17 @@ export const StepTemplate: FC<StepTemplateProps> = ({
         isIndeterminate={isCompleted ? undefined : isIndeterminate}
       >
         {isCompleted && (
-          <CircularProgressLabel>
-            <Icon
-              as={IoCheckmarkSharp}
-              w="100px"
-              h="100px"
-              color={progressBarColor}
-            />
+          <CircularProgressLabel __css={{ svg: { margin: "auto" } }}>
+            {icon}
           </CircularProgressLabel>
         )}
       </CircularProgress>
       {progressBarLabel}
-      <BodyMd as={Box} mt="6" px="3.5">
+      <BodyMd as={Box} mt="6" px="3.5" alignSelf="flex-start">
         {subtitle}
       </BodyMd>
       {txHash && (
-        <BodySm mt="9" color="gray.500" textAlign="center">
+        <BodySm mt="auto" mb="8" color="gray.500" textAlign="center">
           See transaction on{" "}
           <ViewInBlockExplorer
             text={chain === "bitcoin" ? "blockstream" : "etherscan"}
@@ -162,6 +163,7 @@ export const Step1: FC<
       subtitle={subtitle}
       chain="bitcoin"
       txHash={txHash}
+      icon={<BTCConfirmationsIcon />}
       progressBarColor="brand.500"
       progressBarValue={confirmations}
       progressBarMaxValue={requiredConfirmations}
@@ -197,6 +199,7 @@ export const Step2: FC<CommonStepProps> = ({ txHash, onComplete }) => {
           </BodyMd>
         </>
       }
+      icon={<MintingInitializedIcon />}
       chain="ethereum"
       txHash={txHash}
       progressBarColor="yellow.500"
@@ -223,6 +226,7 @@ export const Step3: FC<CommonStepProps> = ({ txHash, onComplete }) => {
           </BodyMd>
         </>
       }
+      icon={<GuardianCheckIcon />}
       chain="ethereum"
       progressBarColor="green.500"
       isCompleted={!!txHash}
@@ -237,6 +241,7 @@ export const Step4: FC<CommonStepProps> = ({ txHash, onComplete }) => {
     <StepTemplate
       title="Minting in progress"
       subtitle="The contract is minting your tBTC tokens."
+      icon={<MintingCompletedIcon />}
       chain="ethereum"
       txHash={txHash}
       progressBarColor="teal.500"

--- a/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
+++ b/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
@@ -9,6 +9,7 @@ import {
   HStack,
   Skeleton,
   Icon,
+  Box,
 } from "@threshold-network/components"
 import { CheckCircleIcon } from "@chakra-ui/icons"
 import { IoCheckmarkSharp } from "react-icons/all"
@@ -20,7 +21,7 @@ import { ONE_SEC_IN_MILISECONDS } from "../../../../utils/date"
 
 type StepTemplateProps = {
   title: string
-  subtitle: string
+  subtitle: string | JSX.Element
   txHash?: string
   chain: ViewInBlockExplorerChain
   progressBarColor: string
@@ -84,7 +85,9 @@ export const StepTemplate: FC<StepTemplateProps> = ({
         )}
       </CircularProgress>
       {progressBarLabel}
-      <BodyMd mt="6">{subtitle}</BodyMd>
+      <BodyMd as={Box} mt="6" px="3.5">
+        {subtitle}
+      </BodyMd>
       {txHash && (
         <BodySm mt="9" color="gray.500" textAlign="center">
           See transaction on{" "}
@@ -176,7 +179,18 @@ export const Step2: FC<CommonStepProps> = ({ txHash, onComplete }) => {
   return (
     <StepTemplate
       title="Minting Initialized"
-      subtitle="A Minter is assessing the minting initialization. If all is well, the Minter will transfer the initialization to the Guardian. Minters are a small group of experts who monitor BTC deposits on the chain."
+      subtitle={
+        <>
+          <BodyMd mb="10">
+            A Minter is assessing the minting initialization.If all is well, the
+            Minter will transfer the initialization to the Guardian.
+          </BodyMd>
+          <BodyMd>
+            Minters are a small group of experts who monitor BTC deposits on the
+            chain.
+          </BodyMd>
+        </>
+      }
       chain="ethereum"
       txHash={txHash}
       progressBarColor="yellow.500"
@@ -191,7 +205,18 @@ export const Step3: FC<CommonStepProps> = ({ txHash, onComplete }) => {
   return (
     <StepTemplate
       title="Guardian Check"
-      subtitle="A Guardian examines the minting request submitted by a Minter. If all is well, the contract proceeds to the minting stage. Guardians verify minting requests and cancel fraudulent mints and remove problematic minters."
+      subtitle={
+        <>
+          <BodyMd mb="10">
+            A Guardian examines the minting request submitted by a Minter. If
+            all is well, the contract proceeds to the minting stage.
+          </BodyMd>
+          <BodyMd>
+            Guardians verify minting requests and cancel fraudulent mints and
+            remove problematic minters.
+          </BodyMd>
+        </>
+      }
       chain="ethereum"
       progressBarColor="green.500"
       isCompleted={!!txHash}

--- a/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
+++ b/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
@@ -25,11 +25,9 @@ import {
 
 type StepTemplateProps = {
   title: string
-  subtitle: string | JSX.Element
   txHash?: string
   chain: ViewInBlockExplorerChain
   progressBarColor: string
-  progressBarLabel?: string | JSX.Element
   isCompleted: boolean
   onComplete: () => void
   isIndeterminate?: boolean
@@ -40,10 +38,8 @@ type StepTemplateProps = {
 
 export const StepTemplate: FC<StepTemplateProps> = ({
   title,
-  subtitle,
   txHash,
   chain,
-  progressBarLabel,
   progressBarValue,
   progressBarMaxValue,
   progressBarColor,
@@ -51,6 +47,7 @@ export const StepTemplate: FC<StepTemplateProps> = ({
   isCompleted,
   onComplete,
   icon,
+  children,
 }) => {
   useEffect(() => {
     if (!isCompleted) return
@@ -91,10 +88,7 @@ export const StepTemplate: FC<StepTemplateProps> = ({
           </CircularProgressLabel>
         )}
       </CircularProgress>
-      {progressBarLabel}
-      <BodyMd as={Box} mt="6" px="3.5" alignSelf="flex-start">
-        {subtitle}
-      </BodyMd>
+      {children}
       {txHash && (
         <BodySm mt="auto" mb="8" color="gray.500" textAlign="center">
           See transaction on{" "}
@@ -160,26 +154,27 @@ export const Step1: FC<
   return (
     <StepTemplate
       title="Waiting for the Bitcoin Network Confirmations..."
-      subtitle={subtitle}
       chain="bitcoin"
       txHash={txHash}
       icon={<BTCConfirmationsIcon />}
       progressBarColor="brand.500"
       progressBarValue={confirmations}
       progressBarMaxValue={requiredConfirmations}
-      progressBarLabel={
-        <BitcoinConfirmationsSummary
-          minConfirmationsNeeded={requiredConfirmations}
-          txConfirmations={confirmations}
-        />
-      }
       isCompleted={Boolean(
         confirmations &&
           requiredConfirmations &&
           confirmations >= requiredConfirmations
       )}
       onComplete={onComplete}
-    />
+    >
+      <BitcoinConfirmationsSummary
+        minConfirmationsNeeded={requiredConfirmations}
+        txConfirmations={confirmations}
+      />
+      <BodyMd mt="6" px="3.5" alignSelf="flex-start">
+        {subtitle}
+      </BodyMd>
+    </StepTemplate>
   )
 }
 
@@ -187,18 +182,6 @@ export const Step2: FC<CommonStepProps> = ({ txHash, onComplete }) => {
   return (
     <StepTemplate
       title="Minting Initialized"
-      subtitle={
-        <>
-          <BodyMd mb="9">
-            A Minter is assessing the minting initialization. If all is well,
-            the Minter will transfer the initialization to the Guardian.
-          </BodyMd>
-          <BodyMd>
-            Minters are a small group of experts who monitor BTC deposits on the
-            chain.
-          </BodyMd>
-        </>
-      }
       icon={<MintingInitializedIcon />}
       chain="ethereum"
       txHash={txHash}
@@ -206,7 +189,18 @@ export const Step2: FC<CommonStepProps> = ({ txHash, onComplete }) => {
       isCompleted={!!txHash}
       onComplete={onComplete}
       isIndeterminate
-    />
+    >
+      <Box mt="6" px="3.5" alignSelf="flex-start">
+        <BodyMd mb="9">
+          A Minter is assessing the minting initialization. If all is well, the
+          Minter will transfer the initialization to the Guardian.
+        </BodyMd>
+        <BodyMd>
+          Minters are a small group of experts who monitor BTC deposits on the
+          chain.
+        </BodyMd>
+      </Box>
+    </StepTemplate>
   )
 }
 
@@ -214,25 +208,24 @@ export const Step3: FC<CommonStepProps> = ({ txHash, onComplete }) => {
   return (
     <StepTemplate
       title="Guardian Check"
-      subtitle={
-        <>
-          <BodyMd mb="9">
-            A Guardian examines the minting request submitted by a Minter. If
-            all is well, the contract proceeds to the minting stage.
-          </BodyMd>
-          <BodyMd>
-            Guardians verify minting requests and cancel fraudulent mints and
-            remove problematic minters.
-          </BodyMd>
-        </>
-      }
       icon={<GuardianCheckIcon />}
       chain="ethereum"
       progressBarColor="green.500"
       isCompleted={!!txHash}
       onComplete={onComplete}
       isIndeterminate
-    />
+    >
+      <Box mt="6" px="3.5" alignSelf="flex-start">
+        <BodyMd mb="9">
+          A Guardian examines the minting request submitted by a Minter. If all
+          is well, the contract proceeds to the minting stage.
+        </BodyMd>
+        <BodyMd>
+          Guardians verify minting requests and cancel fraudulent mints and
+          remove problematic minters.
+        </BodyMd>
+      </Box>
+    </StepTemplate>
   )
 }
 
@@ -240,7 +233,6 @@ export const Step4: FC<CommonStepProps> = ({ txHash, onComplete }) => {
   return (
     <StepTemplate
       title="Minting in progress"
-      subtitle="The contract is minting your tBTC tokens."
       icon={<MintingCompletedIcon />}
       chain="ethereum"
       txHash={txHash}
@@ -248,6 +240,10 @@ export const Step4: FC<CommonStepProps> = ({ txHash, onComplete }) => {
       isCompleted={true}
       onComplete={onComplete}
       isIndeterminate
-    />
+    >
+      <BodyMd mt="6" px="3.5" alignSelf="flex-start">
+        The contract is minting your tBTC tokens.
+      </BodyMd>
+    </StepTemplate>
   )
 }

--- a/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
+++ b/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
@@ -58,7 +58,13 @@ export const StepTemplate: FC<StepTemplateProps> = ({
 
   return (
     <Flex flexDirection="column" alignItems="center">
-      <BodyLg color="gray.700" mt="8" alignSelf="flex-start">
+      <BodyLg
+        color="gray.700"
+        mt="8"
+        alignSelf="flex-start"
+        fontSize="20px"
+        lineHeight="24px"
+      >
         {title}
       </BodyLg>
 
@@ -181,7 +187,7 @@ export const Step2: FC<CommonStepProps> = ({ txHash, onComplete }) => {
       title="Minting Initialized"
       subtitle={
         <>
-          <BodyMd mb="10">
+          <BodyMd mb="9">
             A Minter is assessing the minting initialization.If all is well, the
             Minter will transfer the initialization to the Guardian.
           </BodyMd>
@@ -207,7 +213,7 @@ export const Step3: FC<CommonStepProps> = ({ txHash, onComplete }) => {
       title="Guardian Check"
       subtitle={
         <>
-          <BodyMd mb="10">
+          <BodyMd mb="9">
             A Guardian examines the minting request submitted by a Minter. If
             all is well, the contract proceeds to the minting stage.
           </BodyMd>

--- a/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
+++ b/src/pages/tBTC/Bridge/components/DepositDetailsStep.tsx
@@ -190,8 +190,8 @@ export const Step2: FC<CommonStepProps> = ({ txHash, onComplete }) => {
       subtitle={
         <>
           <BodyMd mb="9">
-            A Minter is assessing the minting initialization. If all is well, the
-            Minter will transfer the initialization to the Guardian.
+            A Minter is assessing the minting initialization. If all is well,
+            the Minter will transfer the initialization to the Guardian.
           </BodyMd>
           <BodyMd>
             Minters are a small group of experts who monitor BTC deposits on the

--- a/src/pages/tBTC/Bridge/components/DepositDetailsStepIcons.tsx
+++ b/src/pages/tBTC/Bridge/components/DepositDetailsStepIcons.tsx
@@ -1,0 +1,133 @@
+export const BTCConfirmationsIcon = () => {
+  return (
+    <svg
+      width="118"
+      height="118"
+      viewBox="0 0 118 118"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M103.941 23.6237C106.28 25.6876 106.517 29.2512 104.473 31.6072L48.4667 96.1568C45.4165 99.6723 40.0207 99.8519 36.7435 96.5469L13.8011 73.4101C11.6036 71.194 11.6036 67.6208 13.8011 65.4047V65.4047C16.0249 63.162 19.6505 63.162 21.8743 65.4047L36.192 79.8437C39.4692 83.1487 44.865 82.9691 47.9153 79.4536L95.8902 24.1604C97.9588 21.7763 101.574 21.5353 103.941 23.6237V23.6237Z"
+        fill="url(#paint0_linear_8221_233096)"
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear_8221_233096"
+          x1="12.7383"
+          y1="23.0976"
+          x2="109.314"
+          y2="89.7981"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#BD30FF" />
+          <stop offset="1" stopColor="#7D00FF" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}
+
+export const MintingInitializedIcon = () => {
+  return (
+    <svg
+      width="118"
+      height="118"
+      viewBox="0 0 118 118"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M103.905 23.3947C106.258 25.4534 106.496 29.0298 104.438 31.3826L48.4463 95.3728C45.3989 98.8555 40.0411 99.0339 36.7688 95.7616L13.8349 72.8276C11.6242 70.6169 11.6242 67.0327 13.8349 64.822V64.822C16.0456 62.6113 19.6298 62.6113 21.8405 64.822L36.2173 79.1988C39.4896 82.4711 44.8474 82.2927 47.8948 78.81L95.9172 23.9272C97.976 21.5744 101.552 21.3359 103.905 23.3947V23.3947Z"
+        fill="url(#paint0_linear_8221_233758)"
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear_8221_233758"
+          x1="12.7383"
+          y1="22.9041"
+          x2="108.786"
+          y2="89.8022"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#F55B5B" />
+          <stop offset="1" stopColor="#FAAD14" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}
+
+export const GuardianCheckIcon = () => {
+  return (
+    <svg
+      width="118"
+      height="118"
+      viewBox="0 0 118 118"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M103.905 23.3947C106.258 25.4534 106.496 29.0298 104.438 31.3826L48.4463 95.3728C45.3989 98.8555 40.0411 99.0339 36.7688 95.7616L13.8349 72.8276C11.6242 70.6169 11.6242 67.0327 13.8349 64.822V64.822C16.0456 62.6113 19.6298 62.6113 21.8405 64.822L36.2173 79.1988C39.4896 82.4711 44.8474 82.2927 47.8948 78.81L95.9172 23.9272C97.976 21.5744 101.552 21.3359 103.905 23.3947V23.3947Z"
+        fill="url(#paint0_linear_8221_234415)"
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear_8221_234415"
+          x1="12.7383"
+          y1="22.9041"
+          x2="108.786"
+          y2="89.8022"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#8FFF00" />
+          <stop offset="1" stopColor="#48BB78" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}
+
+export const MintingCompletedIcon = () => {
+  return (
+    <svg
+      width="118"
+      height="118"
+      viewBox="0 0 118 118"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M103.905 23.3947C106.258 25.4534 106.496 29.0298 104.438 31.3826L48.4463 95.3728C45.3989 98.8555 40.0411 99.0339 36.7688 95.7616L13.8349 72.8276C11.6242 70.6169 11.6242 67.0327 13.8349 64.822V64.822C16.0456 62.6113 19.6298 62.6113 21.8405 64.822L36.2173 79.1988C39.4896 82.4711 44.8474 82.2927 47.8948 78.81L95.9172 23.9272C97.976 21.5744 101.552 21.3359 103.905 23.3947V23.3947Z"
+        fill="url(#paint0_linear_8221_235083)"
+      />
+      <defs>
+        <linearGradient
+          id="paint0_linear_8221_235083"
+          x1="-4709.87"
+          y1="35.5213"
+          x2="-4709.59"
+          y2="117.996"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#31DCED" />
+          <stop offset="0.09" stopColor="#4FC4EC" />
+          <stop offset="0.25" stopColor="#809EEB" />
+          <stop offset="0.41" stopColor="#A87EEB" />
+          <stop offset="0.57" stopColor="#C765EA" />
+          <stop offset="0.73" stopColor="#DE53E9" />
+          <stop offset="0.87" stopColor="#EB49E9" />
+          <stop offset="1" stopColor="#F045E9" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}

--- a/src/pages/tBTC/Bridge/components/MintingProcessResource.tsx
+++ b/src/pages/tBTC/Bridge/components/MintingProcessResource.tsx
@@ -29,8 +29,10 @@ export const MintingProcessResource: FC<MintingProcessResourceProps> = ({
       <H6 mt="8" color="gray.800">
         {title}
       </H6>
-      <BodySm mt="1" color="gray.500" mb="8">
-        {subtitle}{" "}
+      <BodySm mt="1" color="gray.500">
+        {subtitle}
+      </BodySm>
+      <BodySm mb="8">
         <Link isExternal href={link}>
           Read more
         </Link>


### PR DESCRIPTION
This PR fixes UI bugs related to the Visibility of tBTC system feature. Reported bugs: https://coda.io/d/Building-Keep_d-fmEgBNFVH/Sasha-2023-27-03-QA-Template-tBTC-v2_suu17#_lueD-

### Main change
We decided to display the Bitcoin Confirmation Checkpoint even if the confirmation already happened(it's a case when user made a small deposit where only 1 confirmation is needed and the electrum node returns that this transaction alredy has one confirmation.) for around 10 seconds so the users have time to understand what is happening, and then we skip to checkpoint 2. We use this approach only after the reveal transaction, but when we go to the deposit details page directly via `tBTC/mint/deposit/<deposit_key>` link the dapp will display current state- in described case dapp will display the second checkpoint.

Use a custom checkmark icon inside the circular progress bar when the step is completed to use gradients.