### PR TITLE
Fix typo

### DIFF
--- a/src/components/Modal/SelectWalletModal/ConnectTaho.tsx
+++ b/src/components/Modal/SelectWalletModal/ConnectTaho.tsx
@@ -98,7 +98,7 @@ const TahoIsNotSetAsDefaultWallet: FC = () => {
       <AlertDescription>
         Taho is not set as default wallet. Please make sure Taho is{" "}
         <Link isExternal href={ExternalHref.setTahoAsDefaultWallet}>
-          your defaul wallet
+          your default wallet
         </Link>
         , refresh the page and try again.
       </AlertDescription>


### PR DESCRIPTION
Fix typo in Connect Taho modal: `defaul` -> `default`.