### PR TITLE
Remove duplicated `Connect wallet` prompt.

### DIFF
--- a/src/components/Navbar/WalletConnectionAlert.tsx
+++ b/src/components/Navbar/WalletConnectionAlert.tsx
@@ -13,11 +13,12 @@ const WalletConnectionAlert: FC<{
   account?: string | null
   chainId?: number
 }> = ({ account, chainId }) => {
-  const [hideAlert, setHideAlert] = useState(true)
+  const [hideAlert, setHideAlert] = useState(false)
 
   const alertDescription = useMemo(() => {
     if (!account) {
-      return "Connect your wallet"
+      setHideAlert(false)
+      return
     }
 
     if (!isSupportedNetwork(chainId)) {
@@ -28,12 +29,12 @@ const WalletConnectionAlert: FC<{
   }, [account, chainId])
 
   useEffect(() => {
-    if (account && isSupportedNetwork(chainId)) {
+    if (!account || (account && isSupportedNetwork(chainId))) {
       setHideAlert(true)
       return
     }
 
-    if (!account || !isSupportedNetwork(chainId)) {
+    if (!isSupportedNetwork(chainId)) {
       setHideAlert(false)
       return
     }


### PR DESCRIPTION
Closes: #500 

There were two `Connect wallet` prompts in the dApp when the user was not connected. Here we remove one of them (the yellow one below the `Connect wallet` button).