### PR TITLE
Don't run postinstall script separately from `yarn install`

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -42,10 +42,7 @@ jobs:
         run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --frozen-lockfile
-
-      - name: Run token-dashboard post-install script
-        run: yarn run postinstall
+        run: yarn install --frozen-lockfile
 
       - name: Check formatting
         run: yarn format
@@ -80,7 +77,7 @@ jobs:
             @keep-network/tbtc-v2 \
             @keep-network/tbtc-v2.ts \
             @keep-network/ecdsa \
-            @keep-network/random-beacon --ignore-scripts
+            @keep-network/random-beacon
 
       - name: Run postinstall script
         # `yarn upgrade` doesn't trigger the `postinstall` script.

--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -30,10 +30,7 @@ jobs:
         run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts --frozen-lockfile
-
-      - name: Run token-dashboard post-install script
-        run: yarn run postinstall
+        run: yarn install --frozen-lockfile
 
       # FIXME: It's work in progress, the contracts are not yet published.
       # - name: Resolve latest mainnet contracts

--- a/.github/workflows/reusable-build-and-publish.yml
+++ b/.github/workflows/reusable-build-and-publish.yml
@@ -97,11 +97,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: yarn install --ignore-scripts --frozen-lockfile
-
-      - name: Run token-dashboard post-install script
-        shell: bash
-        run: yarn run postinstall
+        run: yarn install --frozen-lockfile
 
       - name: Get upstream packages versions
         if: inputs.useUpstreamBuilds == true


### PR DESCRIPTION
Background:
Previously we've been running postinstall script in a separate step from the `yarn install` command. We've been doing that as a workaround for a problem we had with the postinstall script in the `@threshold-network/solidity-contracts` package (the script in that package often randomly failed). Running `yarn upgrade` with `--ignore-scripts` flag prevented the execution of postinstall script in the main project and its dependencies. And running `yarn run postinstall` after did execute the postinstall script in the main project.

The change:
Recently we have refactored the `@threshold-network/solidity-contracts` project and got rid of the problematic script. We can go back to executing `yarn install` without the `--ignore-scripts` flag.
We still need to execute `yarn run postinstall` in couple of places though - we need to do that after `yarn upgrade` commands, as `yarn upgrade` does not execute the postinstall scripts in the main project (and we have a script in the `threshold-network/token-dashboard` project that we need to execute).

Ref:
https://github.com/threshold-network/solidity-contracts/issues/142
https://github.com/threshold-network/solidity-contracts/pull/143
https://github.com/keep-network/tbtc-v2/pull/629