### PR TITLE
Rename `token-dashboard` repo to `dapp`

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-scripts --frozen-lockfile
 
-      - name: Run token-dashboard post-install script
+      - name: Run dapp post-install script
         run: yarn run postinstall
 
       - name: Check formatting

--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-scripts --frozen-lockfile
 
-      - name: Run token-dashboard post-install script
+      - name: Run dapp post-install script
         run: yarn run postinstall
 
       # FIXME: It's work in progress, the contracts are not yet published.

--- a/.github/workflows/reusable-build-and-publish.yml
+++ b/.github/workflows/reusable-build-and-publish.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
         run: yarn install --ignore-scripts --frozen-lockfile
 
-      - name: Run token-dashboard post-install script
+      - name: Run dapp post-install script
         shell: bash
         run: yarn run postinstall
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Threshold Token Dashboard
 
-[![Token Dashboard / CI](https://github.com/threshold-network/token-dashboard/actions/workflows/dashboard-ci.yml/badge.svg?branch=main&event=push)](https://github.com/threshold-network/token-dashboard/actions/workflows/dashboard-ci.yml)
+[![Token Dashboard / CI](https://github.com/threshold-network/dapp/actions/workflows/dashboard-ci.yml/badge.svg?branch=main&event=push)](https://github.com/threshold-network/dapp/actions/workflows/dashboard-ci.yml)
 [![Docs](https://img.shields.io/badge/docs-website-green)](https://docs.threshold.network)
 [![Chat with us on Discord](https://img.shields.io/badge/chat-Discord-5865f2.svg)](https://discord.gg/threshold)
 
@@ -72,7 +72,7 @@ yarn upgrade @threshold-network/solidity-contracts@goerli \
 using `goerli` tag results in `expected manifest` error - probably caused by bug
 in Yarn: https://github.com/yarnpkg/yarn/issues/4731.
 
-**NOTE 2:** The `token-dashboard` package contains an indirect dependency to
+**NOTE 2:** The `dapp` project contains an indirect dependency to
 `@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
 via unathenticated `git://` protocol. That protocol is no longer supported by
 GitHub. This means that in certain situations installation of the package or
@@ -100,7 +100,7 @@ The following procedure allows to deploy T token dashboard to production:
    and creating a PR with a release branch is not required.
    Dependencies and project version needs to be updated on the release branch.
    All `-dev`, `-goerli` dependencies need to be updated to mainnet versions.
-   See [this commit](https://github.com/threshold-network/token-dashboard/commit/5452b68886ebc514d941a087973dfa9ac3802a7e)
+   See [this commit](https://github.com/threshold-network/dapp/commit/5452b68886ebc514d941a087973dfa9ac3802a7e)
    for `v1.0.0` release as a good example.
 2. Preview of the release branch will be uploaded to `preview.dashboard.threshold.network`
    under the directory named after the release branch. For example:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "token-dashboard",
+  "name": "dapp",
   "version": "1.8.0-pre",
   "private": true,
   "dependencies": {

--- a/src/enums/externalHref.ts
+++ b/src/enums/externalHref.ts
@@ -1,5 +1,5 @@
 export enum ExternalHref {
-  thresholdGithub = "https://github.com/threshold-network/token-dashboard",
+  thresholdGithub = "https://github.com/threshold-network/dapp",
   thresholdDiscord = "https://discord.gg/WXK9PC6SRF",
   metamaskHomePage = "https://metamask.io/",
   stakingContractLeanMore = "https://github.com/threshold-network/solidity-contracts/issues/53",

--- a/src/store/tbtc/tbtcSlice.ts
+++ b/src/store/tbtc/tbtcSlice.ts
@@ -151,5 +151,5 @@ export const registerTBTCListeners = () => {
 }
 
 // TODO: Move to the `../listener` file once we merge
-// https://github.com/threshold-network/token-dashboard/pull/302.
+// https://github.com/threshold-network/dapp/pull/302.
 registerTBTCListeners()

--- a/src/web3/connectors/coinbaseWallet.ts
+++ b/src/web3/connectors/coinbaseWallet.ts
@@ -39,6 +39,6 @@ class CoinbaseWalletConnector extends WalletLinkConnector {
 
 export const coinbaseConnector = new CoinbaseWalletConnector({
   url: rpcUrl,
-  appName: "threshold-token-dashboard",
+  appName: "threshold-dapp",
   supportedChainIds: [+supportedChainId],
 })


### PR DESCRIPTION
We're renaming some of the repositories in the `threshold-network` organization. One of them is `token-dashboard` repo, which will be renamed to `website`. We need to update the references of the old name.