### PR TITLE
Convert script pub key to Bitcoin address

### DIFF
--- a/src/hooks/tbtc/useFetchRedemptionDetails.ts
+++ b/src/hooks/tbtc/useFetchRedemptionDetails.ts
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react"
 import { useThreshold } from "../../contexts/ThresholdContext"
-import { prependScriptPubKeyByLength } from "../../threshold-ts/utils"
-import { isValidType } from "../../threshold-ts/utils/chain"
+import {
+  createAddressFromOutputScript,
+  prependScriptPubKeyByLength,
+  isValidType,
+} from "../../threshold-ts/utils"
 import { useGetBlock } from "../../web3/hooks"
 import { isEmptyOrZeroAddress } from "../../web3/utils"
 
@@ -206,8 +209,10 @@ export const useFetchRedemptionDetails = (
               requestedAt: redemptionRequestedEventTimestamp,
               completedAt: redemptionCompletedTimestamp,
               isTimedOut: false,
-              // TODO: convert the `scriptPubKey` to address.
-              btcAddress: "2Mzs2YNphdHmBoE7SE77cGB57JBXveNGtae",
+              btcAddress: createAddressFromOutputScript(
+                scriptPubKey,
+                threshold.tbtc.bitcoinNetwork
+              ),
             })
 
             return

--- a/src/threshold-ts/utils/bitcoin.ts
+++ b/src/threshold-ts/utils/bitcoin.ts
@@ -3,6 +3,7 @@ import { TransactionHash } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
 export {
   computeHash160,
   createOutputScriptFromAddress,
+  createAddressFromOutputScript,
 } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin"
 import { toBcoinNetwork } from "@keep-network/tbtc-v2.ts/dist/src/bitcoin-network"
 import {


### PR DESCRIPTION
Depends on: #566 

Convert the `scriptPubKey` placed on the output of a Bitcoin
transaction to a Bitcoin address. We want to display the Bitcoin
address in UI instead of the output script.