### PR TITLE
Update copy in the tBTC welcome modal

### DIFF
--- a/src/components/Modal/tBTC/NewTBTCApp.tsx
+++ b/src/components/Modal/tBTC/NewTBTCApp.tsx
@@ -34,7 +34,7 @@ const NewTBTCAppBase: FC<BaseModalProps> = ({ closeModal }) => {
         <BodyLg mb="12" color="gray.500">
           Take note of the following before you proceed.
         </BodyLg>
-        <Flex justifyContent="center">
+        <Flex justifyContent="center" px="10">
           <TakeNoteList size="sm" />
         </Flex>
         <BodySm mt="4.5rem" px="4" textAlign="center" color="gray.500">

--- a/src/components/tBTC/TakeNoteList.tsx
+++ b/src/components/tBTC/TakeNoteList.tsx
@@ -40,7 +40,7 @@ export const TakeNoteList: FC<{ size?: "sm" | "md" }> = ({ size = "md" }) => {
               <Box as="span" color="brand.500">
                 ~ 1 to 3 hours
               </Box>{" "}
-              after you initiate minting.
+              after you initiate minting, depending on your deposited amount.
             </BodyComponent>
           </ListItemWithIcon>
         </List>
@@ -56,6 +56,17 @@ export const TakeNoteList: FC<{ size?: "sm" | "md" }> = ({ size = "md" }) => {
               </Box>
               . Depositing less than the minimum can mean losing access to your
               funds.
+            </BodyComponent>
+          </ListItemWithIcon>
+        </List>
+      </ListItem>
+      <ListItem>
+        <LabelComponent mb="2">Bridging back btc is LIVE</LabelComponent>
+        <List spacing="2">
+          <ListItemWithIcon>
+            <BodyComponent>
+              You can bridge your BTC back whenever you want. Redemptions are
+              now live.
             </BodyComponent>
           </ListItemWithIcon>
         </List>


### PR DESCRIPTION
Closes: https://github.com/threshold-network/token-dashboard/issues/592

Currently the modal displays obsolete data about the redemptions. We need to update the copy of this modal reflecting the new design.

<details>
  <summary>Screenshots</summary>
  
<img width="1269" alt="obraz" src="https://github.com/threshold-network/token-dashboard/assets/57687279/a605bab8-1973-4a07-a626-71696e04c517">

![obraz](https://github.com/threshold-network/token-dashboard/assets/57687279/eda414c6-9e06-42d6-80dd-5a7cd7a550c2)
  
</details>
