### PR TITLE
Fix WalletConnection alert

### DIFF
--- a/src/components/Navbar/WalletConnectionAlert.tsx
+++ b/src/components/Navbar/WalletConnectionAlert.tsx
@@ -15,7 +15,7 @@ const WalletConnectionAlert: FC<{
   chainId?: number
 }> = ({ account, chainId }) => {
   const [hideAlert, setHideAlert] = useState(false)
-  const { error } = useWeb3React()
+  const { error, deactivate } = useWeb3React()
   const [alertDescription, setAlertDescription] = useState("")
 
   const errorMessage = error?.message
@@ -46,7 +46,7 @@ const WalletConnectionAlert: FC<{
   const resetAlert = () => {
     setHideAlert(true)
     setAlertDescription("")
-    if (error) error.message = ""
+    deactivate()
   }
 
   if (hideAlert) {

--- a/src/components/Navbar/WalletConnectionAlert.tsx
+++ b/src/components/Navbar/WalletConnectionAlert.tsx
@@ -46,6 +46,7 @@ const WalletConnectionAlert: FC<{
   const resetAlert = () => {
     setHideAlert(true)
     setAlertDescription("")
+    if (error) error.message = ""
   }
 
   if (hideAlert) {


### PR DESCRIPTION
There was a bug that caused the walletconnection alert to not show up the second time if the error message stays the same.

This commit fixes that.

<img width="460" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/4ea945f9-d9fe-4ae3-960e-4cb34f02d6a3">

To see if it works you can:
1. Click "Connect  Wallet"
2. Choose "WalletConnect"
3. Close the WalletConnect modal with `X` button
4. The "Connection request reset. Please try again" alert should appear in the top right corner.
5. Close the alert
6. Repeat steps 1-3
7. The "Connection request reset. Please try again" alert should appear again