### PR TITLE
🌓 Dark mode fixes

### DIFF
--- a/src/components/Forms/FormikInput.tsx
+++ b/src/components/Forms/FormikInput.tsx
@@ -74,6 +74,7 @@ export const FormikInput: FC<
         isInvalid={isError}
         errorBorderColor="red.300"
         placeholder={placeholder}
+        _placeholder={{ color: useColorModeValue("gray.400", "gray.500") }}
         {...field}
         value={meta.value}
       />

--- a/src/components/OutlineListItem.tsx
+++ b/src/components/OutlineListItem.tsx
@@ -1,5 +1,9 @@
 import { FC } from "react"
-import { ListItem, ListItemProps } from "@threshold-network/components"
+import {
+  ListItem,
+  ListItemProps,
+  useColorModeValue,
+} from "@threshold-network/components"
 
 export const OutlineListItem: FC<ListItemProps> = ({ ...props }) => {
   return (
@@ -7,7 +11,7 @@ export const OutlineListItem: FC<ListItemProps> = ({ ...props }) => {
       display="flex"
       justifyContent="space-between"
       alignItems="center"
-      borderColor="gray.100"
+      borderColor={useColorModeValue("gray.100", "gray.700")}
       borderWidth="1px"
       borderStyle="solid"
       borderRadius="6px"

--- a/src/components/OutlineListItem.tsx
+++ b/src/components/OutlineListItem.tsx
@@ -6,12 +6,14 @@ import {
 } from "@threshold-network/components"
 
 export const OutlineListItem: FC<ListItemProps> = ({ ...props }) => {
+  const borderColor = useColorModeValue("gray.100", "gray.700")
+
   return (
     <ListItem
       display="flex"
       justifyContent="space-between"
       alignItems="center"
-      borderColor={useColorModeValue("gray.100", "gray.700")}
+      borderColor={borderColor}
       borderWidth="1px"
       borderStyle="solid"
       borderRadius="6px"

--- a/src/components/Step/index.tsx
+++ b/src/components/Step/index.tsx
@@ -126,6 +126,7 @@ export const Step: FC<StepProps> = ({
   ...restProps
 }) => {
   const { size } = useStepsContext()
+  const activeBorderColor = useColorModeValue("brand.500", "brand.300")
 
   return (
     <StepContext.Provider
@@ -140,11 +141,7 @@ export const Step: FC<StepProps> = ({
         w="full"
         borderLeftWidth="4px"
         borderLeftStyle="solid"
-        borderColor={
-          isActive || isComplete
-            ? useColorModeValue("brand.500", "brand.300")
-            : "gray.300"
-        }
+        borderColor={isActive || isComplete ? activeBorderColor : "gray.300"}
         {...restProps}
       >
         {children}
@@ -158,11 +155,12 @@ export const StepIndicator: FC<ComponentProps<typeof LabelSm>> = ({
   ...restProps
 }) => {
   const { size } = useStepContext()
+  const textColor = useColorModeValue("brand.500", "brand.300")
 
   const Label = stepSizeMap[size].label.component
 
   return (
-    <Label color={useColorModeValue("brand.500", "brand.300")} {...restProps}>
+    <Label color={textColor} {...restProps}>
       {children}
     </Label>
   )

--- a/src/components/Step/index.tsx
+++ b/src/components/Step/index.tsx
@@ -14,6 +14,7 @@ import {
   Badge,
   ImageProps,
   Image,
+  useColorModeValue,
 } from "@threshold-network/components"
 
 type Sizes = "sm" | "md" | "lg"
@@ -139,7 +140,11 @@ export const Step: FC<StepProps> = ({
         w="full"
         borderLeftWidth="4px"
         borderLeftStyle="solid"
-        borderColor={isActive || isComplete ? "brand.500" : "gray.300"}
+        borderColor={
+          isActive || isComplete
+            ? useColorModeValue("brand.500", "brand.300")
+            : "gray.300"
+        }
         {...restProps}
       >
         {children}
@@ -157,7 +162,7 @@ export const StepIndicator: FC<ComponentProps<typeof LabelSm>> = ({
   const Label = stepSizeMap[size].label.component
 
   return (
-    <Label color="brand.500" {...restProps}>
+    <Label color={useColorModeValue("brand.500", "brand.300")} {...restProps}>
       {children}
     </Label>
   )

--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -1,5 +1,10 @@
 import { ComponentProps, FC } from "react"
-import { BodySm, ListItem, Skeleton } from "@threshold-network/components"
+import {
+  BodySm,
+  ListItem,
+  Skeleton,
+  useColorModeValue,
+} from "@threshold-network/components"
 import { InlineTokenBalance } from "../TokenBalance"
 
 type TransactionDetailsItemProps = {
@@ -15,7 +20,13 @@ export const TransactionDetailsItem: FC<TransactionDetailsItemProps> = ({
   return (
     <ListItem display="flex" justifyContent="space-between" alignItems="center">
       <BodySm color="gray.500">{label}</BodySm>
-      {value ? <BodySm color="gray.700">{value}</BodySm> : children}
+      {value ? (
+        <BodySm color={useColorModeValue("gray.700", "gray.300")}>
+          {value}
+        </BodySm>
+      ) : (
+        children
+      )}
     </ListItem>
   )
 }
@@ -32,7 +43,7 @@ export const TransactionDetailsAmountItem: FC<
   return (
     <TransactionDetailsItem label={label}>
       <Skeleton isLoaded={!!tokenAmount}>
-        <BodySm color="gray.700">
+        <BodySm color={useColorModeValue("gray.700", "gray.300")}>
           <InlineTokenBalance
             withSymbol
             tokenAmount={tokenAmount || "0"}

--- a/src/components/TransactionDetails/index.tsx
+++ b/src/components/TransactionDetails/index.tsx
@@ -17,16 +17,12 @@ export const TransactionDetailsItem: FC<TransactionDetailsItemProps> = ({
   value,
   children,
 }) => {
+  const valueTextColor = useColorModeValue("gray.700", "gray.300")
+
   return (
     <ListItem display="flex" justifyContent="space-between" alignItems="center">
       <BodySm color="gray.500">{label}</BodySm>
-      {value ? (
-        <BodySm color={useColorModeValue("gray.700", "gray.300")}>
-          {value}
-        </BodySm>
-      ) : (
-        children
-      )}
+      {value ? <BodySm color={valueTextColor}>{value}</BodySm> : children}
     </ListItem>
   )
 }
@@ -40,10 +36,12 @@ type TransactionDetailsAmountItemProps = Omit<
 export const TransactionDetailsAmountItem: FC<
   TransactionDetailsAmountItemProps
 > = ({ label, tokenAmount, ...restProps }) => {
+  const tokenBalanceTextColor = useColorModeValue("gray.700", "gray.300")
+
   return (
     <TransactionDetailsItem label={label}>
       <Skeleton isLoaded={!!tokenAmount}>
-        <BodySm color={useColorModeValue("gray.700", "gray.300")}>
+        <BodySm color={tokenBalanceTextColor}>
           <InlineTokenBalance
             withSymbol
             tokenAmount={tokenAmount || "0"}

--- a/src/components/tBTC/RecentDeposits.tsx
+++ b/src/components/tBTC/RecentDeposits.tsx
@@ -39,6 +39,8 @@ const RecentDepositItem: FC<RecentDeposit> = ({
   date,
   txHash,
 }) => {
+  const tokenBalanceTextColor = useColorModeValue("brand.500", "brand.300")
+
   return (
     <LinkBox as={OutlineListItem}>
       <LinkOverlay
@@ -64,7 +66,7 @@ const RecentDepositItem: FC<RecentDeposit> = ({
             tokenAmount={amount}
             withSymbol
             tokenSymbol="tBTC"
-            color={useColorModeValue("brand.500", "brand.300")}
+            color={tokenBalanceTextColor}
           />
         </BodySm>
       </LinkOverlay>

--- a/src/components/tBTC/RecentDeposits.tsx
+++ b/src/components/tBTC/RecentDeposits.tsx
@@ -7,6 +7,7 @@ import {
   LinkBox,
   LinkOverlay,
   Link,
+  useColorModeValue,
 } from "@threshold-network/components"
 import shortenAddress from "../../utils/shortenAddress"
 import Identicon from "../Identicon"
@@ -63,7 +64,7 @@ const RecentDepositItem: FC<RecentDeposit> = ({
             tokenAmount={amount}
             withSymbol
             tokenSymbol="tBTC"
-            color="brand.500"
+            color={useColorModeValue("brand.500", "brand.300")}
           />
         </BodySm>
       </LinkOverlay>

--- a/src/pages/tBTC/Bridge/DepositDetails.tsx
+++ b/src/pages/tBTC/Bridge/DepositDetails.tsx
@@ -17,18 +17,16 @@ import {
   LabelSm,
   List,
   ListItem,
-  Skeleton,
   Stack,
   StackDivider,
   Icon,
   Divider,
-  SkeletonText,
-  SkeletonCircle,
   BodySm,
   BodyXs,
   Alert,
   AlertDescription,
   AlertIcon,
+  useColorModeValue,
 } from "@threshold-network/components"
 import { IoCheckmarkSharp, IoTime as TimeIcon } from "react-icons/all"
 import { InlineTokenBalance } from "../../../components/TokenBalance"
@@ -208,7 +206,11 @@ export const DepositDetails: PageComponent = () => {
                 <BridgeProcessCardTitle />
                 <Flex mb="4" alignItems="center" textStyle="bodyLg">
                   <BodyLg>
-                    <Box as="span" fontWeight="600" color="brand.500">
+                    <Box
+                      as="span"
+                      fontWeight="600"
+                      color={useColorModeValue("brand.500", "brand.300")}
+                    >
                       {mintingProgressStep === "completed"
                         ? "Minted"
                         : "Minting"}

--- a/src/pages/tBTC/Bridge/DepositDetails.tsx
+++ b/src/pages/tBTC/Bridge/DepositDetails.tsx
@@ -88,6 +88,8 @@ export const DepositDetails: PageComponent = () => {
   const { mintingRequestedTxHash, mintingFinalizedTxHash } =
     useSubscribeToOptimisticMintingEvents(depositKey)
 
+  const depositStatusTextColor = useColorModeValue("brand.500", "brand.300")
+
   // Cache the location state in component state.
   const [locationStateCache] = useState<{ shouldStartFromFirstStep?: boolean }>(
     (state as { shouldStartFromFirstStep?: boolean }) || {}
@@ -209,7 +211,7 @@ export const DepositDetails: PageComponent = () => {
                     <Box
                       as="span"
                       fontWeight="600"
-                      color={useColorModeValue("brand.500", "brand.300")}
+                      color={depositStatusTextColor}
                     >
                       {mintingProgressStep === "completed"
                         ? "Minted"

--- a/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
@@ -1,6 +1,10 @@
 import { FC, Ref, useRef, useState } from "react"
 import { FormikErrors, FormikProps, withFormik } from "formik"
-import { Button, BodyMd } from "@threshold-network/components"
+import {
+  Button,
+  BodyMd,
+  useColorModeValue,
+} from "@threshold-network/components"
 import { useTbtcState } from "../../../../hooks/useTbtcState"
 import { BridgeProcessCardTitle } from "../components/BridgeProcessCardTitle"
 import { BridgeProcessCardSubTitle } from "../components/BridgeProcessCardSubTitle"
@@ -167,7 +171,7 @@ export const ProvideDataComponent: FC<{
         stepText="Step 1"
         subTitle="Generate a Deposit Address"
       />
-      <BodyMd color="gray.500" mb={12}>
+      <BodyMd color={useColorModeValue("gray.500", "gray.300")} mb={12}>
         Based on these two addresses, the system will generate for you a unique
         BTC deposit address. There is no minting limit.
       </BodyMd>

--- a/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
@@ -111,6 +111,8 @@ export const ProvideDataComponent: FC<{
   const { setDepositDataInLocalStorage } = useTBTCDepositDataFromLocalStorage()
   const depositTelemetry = useDepositTelemetry(threshold.tbtc.bitcoinNetwork)
 
+  const textColor = useColorModeValue("gray.500", "gray.300")
+
   const onSubmit = async (values: FormValues) => {
     if (account && !isSameETHAddress(values.ethAddress, account)) {
       throw new Error(
@@ -171,7 +173,7 @@ export const ProvideDataComponent: FC<{
         stepText="Step 1"
         subTitle="Generate a Deposit Address"
       />
-      <BodyMd color={useColorModeValue("gray.500", "gray.300")} mb={12}>
+      <BodyMd color={textColor} mb={12}>
         Based on these two addresses, the system will generate for you a unique
         BTC deposit address. There is no minting limit.
       </BodyMd>

--- a/src/pages/tBTC/Bridge/components/BridgeProcessCardSubTitle.tsx
+++ b/src/pages/tBTC/Bridge/components/BridgeProcessCardSubTitle.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps, FC } from "react"
-import { BodyLg, Box } from "@threshold-network/components"
+import { BodyLg, Box, useColorModeValue } from "@threshold-network/components"
 
 export const BridgeProcessCardSubTitle: FC<
   {
@@ -9,7 +9,11 @@ export const BridgeProcessCardSubTitle: FC<
 > = ({ stepText, subTitle, children, ...restProps }) => {
   return (
     <BodyLg mb={4} {...restProps}>
-      <Box as="span" fontWeight="bold" color="brand.500">
+      <Box
+        as="span"
+        fontWeight="bold"
+        color={useColorModeValue("brand.500", "brand.300")}
+      >
         {stepText}
       </Box>
       {subTitle ? ` - ${subTitle}` : children}

--- a/src/pages/tBTC/Bridge/components/BridgeProcessCardSubTitle.tsx
+++ b/src/pages/tBTC/Bridge/components/BridgeProcessCardSubTitle.tsx
@@ -7,13 +7,11 @@ export const BridgeProcessCardSubTitle: FC<
     subTitle?: string
   } & ComponentProps<typeof BodyLg>
 > = ({ stepText, subTitle, children, ...restProps }) => {
+  const mainTextColor = useColorModeValue("brand.500", "brand.300")
+
   return (
     <BodyLg mb={4} {...restProps}>
-      <Box
-        as="span"
-        fontWeight="bold"
-        color={useColorModeValue("brand.500", "brand.300")}
-      >
+      <Box as="span" fontWeight="bold" color={mainTextColor}>
         {stepText}
       </Box>
       {subTitle ? ` - ${subTitle}` : children}

--- a/src/pages/tBTC/Bridge/components/BridgeProcessEmptyState.tsx
+++ b/src/pages/tBTC/Bridge/components/BridgeProcessEmptyState.tsx
@@ -18,6 +18,10 @@ export const BridgeProcessEmptyState: FC<{
 }> = ({ title, bridgeProcess = "mint" }) => {
   const [tvlInUSD, fetchTvl, tvl] = useFetchTvl()
   const [deposits] = useFetchRecentDeposits(3)
+  const protocolHistoryBackgroundColor = useColorModeValue(
+    "linear-gradient(360deg, #FFFFFF 0%, rgba(255, 255, 255, 0) 117.78%)",
+    "linear-gradient(360deg, #333A47 0%, rgba(255, 255, 255, 0) 117.78%)"
+  )
 
   useEffect(() => {
     fetchTvl()
@@ -40,10 +44,7 @@ export const BridgeProcessEmptyState: FC<{
           width: "100%",
           height: "100px",
           opacity: "0.9",
-          background: useColorModeValue(
-            "linear-gradient(360deg, #FFFFFF 0%, rgba(255, 255, 255, 0) 117.78%)",
-            "linear-gradient(360deg, #333A47 0%, rgba(255, 255, 255, 0) 117.78%)"
-          ),
+          background: protocolHistoryBackgroundColor,
         }}
       />
       <ProtocolHistoryViewMoreLink mt="7" />

--- a/src/pages/tBTC/Bridge/components/BridgeProcessEmptyState.tsx
+++ b/src/pages/tBTC/Bridge/components/BridgeProcessEmptyState.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react"
-import { H5 } from "@threshold-network/components"
+import { H5, useColorModeValue } from "@threshold-network/components"
 import { BridgeProcessCardTitle } from "./BridgeProcessCardTitle"
 import SubmitTxButton from "../../../../components/SubmitTxButton"
 import {
@@ -40,8 +40,10 @@ export const BridgeProcessEmptyState: FC<{
           width: "100%",
           height: "100px",
           opacity: "0.9",
-          background:
+          background: useColorModeValue(
             "linear-gradient(360deg, #FFFFFF 0%, rgba(255, 255, 255, 0) 117.78%)",
+            "linear-gradient(360deg, #4A5568 0%, rgba(255, 255, 255, 0) 117.78%)"
+          ),
         }}
       />
       <ProtocolHistoryViewMoreLink mt="7" />

--- a/src/pages/tBTC/Bridge/components/BridgeProcessEmptyState.tsx
+++ b/src/pages/tBTC/Bridge/components/BridgeProcessEmptyState.tsx
@@ -42,7 +42,7 @@ export const BridgeProcessEmptyState: FC<{
           opacity: "0.9",
           background: useColorModeValue(
             "linear-gradient(360deg, #FFFFFF 0%, rgba(255, 255, 255, 0) 117.78%)",
-            "linear-gradient(360deg, #4A5568 0%, rgba(255, 255, 255, 0) 117.78%)"
+            "linear-gradient(360deg, #333A47 0%, rgba(255, 255, 255, 0) 117.78%)"
           ),
         }}
       />

--- a/src/pages/tBTC/Bridge/components/BridgeProcessStep.tsx
+++ b/src/pages/tBTC/Bridge/components/BridgeProcessStep.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
   CircularProgressLabel,
   Flex,
+  useColorModeValue,
 } from "@threshold-network/components"
 import ViewInBlockExplorer, {
   Chain as ViewInBlockExplorerChain,
@@ -51,7 +52,7 @@ export const BridgeProcessStep: FC<BridgeProcessStepProps> = ({
   return (
     <Flex flexDirection="column" alignItems="center" height="100%">
       <BodyLg
-        color="gray.700"
+        color={useColorModeValue("gray.700", "gray.300")}
         mt="8"
         alignSelf="flex-start"
         fontSize="20px"

--- a/src/pages/tBTC/Bridge/components/BridgeProcessStep.tsx
+++ b/src/pages/tBTC/Bridge/components/BridgeProcessStep.tsx
@@ -39,6 +39,8 @@ export const BridgeProcessStep: FC<BridgeProcessStepProps> = ({
   icon,
   children,
 }) => {
+  const titleTextColor = useColorModeValue("gray.700", "gray.300")
+
   useEffect(() => {
     if (!isCompleted) return
 
@@ -52,7 +54,7 @@ export const BridgeProcessStep: FC<BridgeProcessStepProps> = ({
   return (
     <Flex flexDirection="column" alignItems="center" height="100%">
       <BodyLg
-        color={useColorModeValue("gray.700", "gray.300")}
+        color={titleTextColor}
         mt="8"
         alignSelf="flex-start"
         fontSize="20px"

--- a/src/pages/tBTC/Explorer/index.tsx
+++ b/src/pages/tBTC/Explorer/index.tsx
@@ -220,7 +220,7 @@ const MetricBox: FC = ({ children }) => {
       textAlign="center"
       borderRadius="2"
       minWidth="294px"
-      color="grat.700"
+      color="gray.700"
     >
       {children}
     </Box>

--- a/src/pages/tBTC/Explorer/index.tsx
+++ b/src/pages/tBTC/Explorer/index.tsx
@@ -118,7 +118,7 @@ export const ExplorerPage: PageComponent = () => {
         <LabelSm as="header">History</LabelSm>
         <TableContainer mt="6">
           <Table variant="simple">
-            <Thead color="gray.500">
+            <Thead>
               <Tr>
                 <Th paddingLeft={12}>
                   <LabelXs color="gray.500">
@@ -126,13 +126,13 @@ export const ExplorerPage: PageComponent = () => {
                   </LabelXs>
                 </Th>
                 <Th>
-                  <LabelXs>Wallet Address</LabelXs>
+                  <LabelXs color="gray.500">Wallet Address</LabelXs>
                 </Th>
                 <Th>
-                  <LabelXs>TX Hash</LabelXs>
+                  <LabelXs color="gray.500">TX Hash</LabelXs>
                 </Th>
                 <Th textAlign={"right"}>
-                  <LabelXs>Timestamp</LabelXs>
+                  <LabelXs color="gray.500">Timestamp</LabelXs>
                 </Th>
               </Tr>
             </Thead>

--- a/src/pages/tBTC/Explorer/index.tsx
+++ b/src/pages/tBTC/Explorer/index.tsx
@@ -24,6 +24,7 @@ import {
   Th,
   Thead,
   Tr,
+  useColorModeValue,
 } from "@threshold-network/components"
 import { PageComponent } from "../../../types"
 import tBTCExplorerBg from "../../../static/images/tBTC-explorer-bg.svg"
@@ -155,7 +156,7 @@ const HistoryRow: FC<RecentDeposit> = ({ txHash, address, amount, date }) => {
     <LinkBox
       as={Tr}
       key={`latest-mints-${txHash}`}
-      _odd={{ backgroundColor: "gray.50" }}
+      _odd={{ backgroundColor: useColorModeValue("gray.50", "gray.700") }}
       sx={{ td: { borderBottom: "none" } }}
       transform="scale(1)"
     >
@@ -216,7 +217,7 @@ const MetricBox: FC = ({ children }) => {
       border="1px solid"
       borderColor="gray.100"
       p="3.25rem"
-      bg="white"
+      bg={useColorModeValue("white", "gray.700")}
       textAlign="center"
       borderRadius="2"
       minWidth="294px"

--- a/src/pages/tBTC/Explorer/index.tsx
+++ b/src/pages/tBTC/Explorer/index.tsx
@@ -152,11 +152,13 @@ const renderHistoryRow = (item: RecentDeposit) => (
 )
 
 const HistoryRow: FC<RecentDeposit> = ({ txHash, address, amount, date }) => {
+  const oddRowBackgroundColor = useColorModeValue("gray.50", "gray.700")
+
   return (
     <LinkBox
       as={Tr}
       key={`latest-mints-${txHash}`}
-      _odd={{ backgroundColor: useColorModeValue("gray.50", "gray.700") }}
+      _odd={{ backgroundColor: oddRowBackgroundColor }}
       sx={{ td: { borderBottom: "none" } }}
       transform="scale(1)"
     >
@@ -212,12 +214,15 @@ const SimpleMetricBox: FC<{ value: string; label: string }> = ({
 }
 
 const MetricBox: FC = ({ children }) => {
+  const borderColor = useColorModeValue("gray.100", "gray.500")
+  const backgroundColor = useColorModeValue("white", "gray.700")
+
   return (
     <Box
       border="1px solid"
-      borderColor={useColorModeValue("gray.100", "gray.500")}
+      borderColor={borderColor}
       p="3.25rem"
-      bg={useColorModeValue("white", "gray.700")}
+      bg={backgroundColor}
       textAlign="center"
       borderRadius="2"
       minWidth="294px"

--- a/src/pages/tBTC/Explorer/index.tsx
+++ b/src/pages/tBTC/Explorer/index.tsx
@@ -215,7 +215,7 @@ const MetricBox: FC = ({ children }) => {
   return (
     <Box
       border="1px solid"
-      borderColor="gray.100"
+      borderColor={useColorModeValue("gray.100", "gray.500")}
       p="3.25rem"
       bg={useColorModeValue("white", "gray.700")}
       textAlign="center"


### PR DESCRIPTION
Closes: #435 

Also fixes the dark mode issues that were placed in Coda (see [here](https://coda.io/d/Building-Keep_d-fmEgBNFVH/Sorin-2023-18-07-QA-tBTC-v2-Unmint-flow_suH93#_luYJg), [here](https://coda.io/d/Building-Keep_d-fmEgBNFVH/Sorin-2023-18-07-QA-tBTC-v2-Mint-flow_suSRo#_lu3C0) and [here](https://coda.io/d/Building-Keep_d-fmEgBNFVH/Sorin-2023-18-07-QA-tBTC-v2-dApp-issues_suMvR#_luV5k))

### Fixes:
---
#### 1. Change OutlineListItem color for dark mode - b274717d798801163ecb6f5df1a48c984cd191c5

Changes the color of the border for `MY ACTIVITY` items

<details>
  <summary>Screenshots</summary>

 Before:
 
<img width="302" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/b02a14ef-cc14-413f-99f4-4207d1afd054">


After:
<img width="292" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/0f65fece-bd74-4b2c-adc7-db106147f265">

</details>

---

#### 2. Fix darkmode color for BridgeProcessStep - b914db0f14a1ba8216490420bf62b0cb34313ff2

Changes the color of the title of BridgeProcessStep (for example `Unminting in progress`)

<details>
  <summary>Screenshots</summary>

 Before:
 
<TODO>


After:
<TODO>

</details>

---

#### 3. Fix color for TransactionDetailsItem (dark mode) - a573ff46cc4040bda6a138c49f2ce7b030eb8408

Makes the TransactionDetailsItem values lighter

<details>
  <summary>Screenshots</summary>

 Before:
 
<TODO>


After:
![image](https://github.com/threshold-network/token-dashboard/assets/40306834/d418d54f-1069-4d9e-b21b-6efa0beb2a09)

</details>

---

#### 4. Fix color for bridge process step subtitles  - 125b257cf3eca0a90b4f49d279fb841b34c79872

Makes the Bridge Process Step subtitle lighter.

<details>
  <summary>Screenshots</summary>

 Before:
![image](https://github.com/threshold-network/token-dashboard/assets/40306834/f8ae5add-1e4e-440d-9dff-f337bc31d01a)

<img width="255" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/3dbcf700-bbf8-4804-a9b5-98ed15731920">



After:
![image](https://github.com/threshold-network/token-dashboard/assets/40306834/79eeb5ad-fb0c-407b-a3f9-ca6f891cd8b3)

![image](https://github.com/threshold-network/token-dashboard/assets/40306834/02664264-0298-4037-887d-39035764bda4)

</details>

---

#### 5. Fix the colors in Step component (dark mode) - 72da36ebb4d44e6862ec0b1cb500ea8baea52c11

<details>
  <summary>Screenshots</summary>

 Before:
<img width="251" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/d09b9382-5ad8-4053-8ebd-e0f093647d29">

After:
![image](https://github.com/threshold-network/token-dashboard/assets/40306834/0ffae678-624b-4ffe-82ed-edc213919f39)

</details>

---

#### 6. Fix ProtocolHistory colors for dark mode - 7ed978529924a224a3336434989b34ead56c4943

<details>
  <summary>Screenshots</summary>

 Before:
<img width="506" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/8484d723-bbe5-49b0-befa-77856819fffa">

After:
![image](https://github.com/threshold-network/token-dashboard/assets/40306834/5927e432-bf85-45b0-9b1e-08ddd050aab5)

</details>

---

#### 7. Fix dark mode issues for step 1 minting - 363f759f157a1b221222a56d737a1077dcdbed0f

- change body text to gray.300 for dark mode
- change placeholder text for the input to gray.500 for dark mode

<details>
  <summary>Screenshots</summary>

 Before:
<img width="497" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/72545041-7d41-4a77-af8b-be105b8216c5">

After:
![image](https://github.com/threshold-network/token-dashboard/assets/40306834/6b804036-a5cf-42d8-8e30-2d12c957bdc3)

</details>

---

#### 8. Fix dark mode colors for tBTC Explorer - 9ae95cdd514eaffba63af5ec8fb758d03fc61f1f

<details>
  <summary>Screenshots</summary>

 Before:
<img width="780" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/01d95992-d5a2-4683-81be-01b4376ddd92">

After:
<img width="770" alt="image" src="https://github.com/threshold-network/token-dashboard/assets/40306834/c71dcbf3-8754-4fda-89cc-7220696d81e6">

</details>