### PR TITLE
🔨 📄 🔧  Fix tbtc tests

### DIFF
--- a/src/components/tBTC/BridgeActivity.tsx
+++ b/src/components/tBTC/BridgeActivity.tsx
@@ -19,7 +19,7 @@ import {
 import {
   BridgeActivityStatus,
   BridgeActivity as BridgeActivityType,
-  UnminBridgeActivityAdditionalData,
+  UnmintBridgeActivityAdditionalData,
 } from "../../threshold-ts/tbtc"
 import emptyHistoryImageSrcDark from "../../static/images/tBTC-bridge-no-history-dark.svg"
 import emptyHistoryImageSrcLight from "../../static/images/tBTC-bridge-no-history-light.svg"
@@ -112,11 +112,11 @@ const ActivityItem: FC<BridgeActivityType> = ({
       ? RedemptionDetailsLinkBuilder.createFromTxHash(txHash)
           .withRedeemer(account!)
           .withRedeemerOutputScript(
-            (additionalData as UnminBridgeActivityAdditionalData)
+            (additionalData as UnmintBridgeActivityAdditionalData)
               .redeemerOutputScript
           )
           .withWalletPublicKeyHash(
-            (additionalData as UnminBridgeActivityAdditionalData)
+            (additionalData as UnmintBridgeActivityAdditionalData)
               .walletPublicKeyHash
           )
           .build()

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -44,6 +44,7 @@ jest.mock("@keep-network/tbtc-v2.ts/dist/src/bitcoin", () => ({
 jest.mock("@keep-network/tbtc-v2.ts/dist/src", () => ({
   EthereumBridge: jest.fn(),
   ElectrumClient: jest.fn(),
+  EthereumTBTCToken: jest.fn(),
 }))
 
 jest.mock("crypto-js")

--- a/src/store/tbtc/tbtcSlice.ts
+++ b/src/store/tbtc/tbtcSlice.ts
@@ -5,7 +5,7 @@ import { UpdateStateActionPayload } from "../../types/state"
 import {
   BridgeActivityStatus,
   BridgeActivity,
-  UnminBridgeActivityAdditionalData,
+  UnmintBridgeActivityAdditionalData,
 } from "../../threshold-ts/tbtc"
 import { featureFlags } from "../../constants"
 import { startAppListening } from "../listener"
@@ -127,7 +127,7 @@ export const tbtcSlice = createSlice({
         blockNumber: number
         amount: string
         txHash: string
-        additionalData: UnminBridgeActivityAdditionalData
+        additionalData: UnmintBridgeActivityAdditionalData
       }>
     ) => {
       const {

--- a/src/threshold-ts/tbtc/index.ts
+++ b/src/threshold-ts/tbtc/index.ts
@@ -77,7 +77,7 @@ export interface BridgeActivity {
   blockNumber: number
 }
 
-export interface UnminBridgeActivityAdditionalData {
+export interface UnmintBridgeActivityAdditionalData {
   redeemerOutputScript: string
   walletPublicKeyHash: string
 }
@@ -909,7 +909,7 @@ export class TBTC implements ITBTC {
         additionalData: {
           redeemerOutputScript: event.redeemerOutputScript,
           walletPublicKeyHash: event.walletPublicKeyHash,
-        } as UnminBridgeActivityAdditionalData,
+        } as UnmintBridgeActivityAdditionalData,
       })
     }
 


### PR DESCRIPTION
Some of the tests related to `bridgeActivity` were failing after we updated the code with `Unmint` feature. This PR fixes that.

Note: We might want to add more tests to the Redemption in the future.