### PR TITLE
Add conditional rendering for authorization alert

### DIFF
--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -115,8 +115,9 @@ const AuthorizeStakingAppsPage: FC = () => {
   }
 
   const isFullyAuthorized = Object.values(appsAuthData).every(
-    ({ status }) =>
-      status === "authorized" || status === "authorization-not-required"
+    ({ status, percentage }) =>
+      (status === "authorized" && percentage === 100) ||
+      status === "authorization-not-required"
   )
 
   useEffect(() => {

--- a/src/pages/Staking/AuthorizeStakingApps/index.tsx
+++ b/src/pages/Staking/AuthorizeStakingApps/index.tsx
@@ -114,6 +114,11 @@ const AuthorizeStakingAppsPage: FC = () => {
     },
   }
 
+  const isFullyAuthorized = Object.values(appsAuthData).every(
+    ({ status }) =>
+      status === "authorized" || status === "authorization-not-required"
+  )
+
   useEffect(() => {
     if (tbtcApp.isAuthorized) {
       setSelectedApps((selectedApps) =>
@@ -245,13 +250,17 @@ const AuthorizeStakingAppsPage: FC = () => {
             </AlertDescription>
           </AlertBox>
         )}
-        <AlertBox status="magic" alignItems="flex-start">
-          <AlertDescription color={alertTextColor}>
-            In order to earn rewards, please authorize Threshold apps to use
-            your stake. Note that you can authorize 100% of your stake for all
-            of the apps. You can change this amount at any time.
-          </AlertDescription>
-        </AlertBox>
+
+        {!isFullyAuthorized && (
+          <AlertBox status="magic" alignItems="flex-start">
+            <AlertDescription color={alertTextColor}>
+              In order to earn rewards, please authorize Threshold apps to use
+              your stake. Note that you can authorize 100% of your stake for all
+              of the apps. You can change this amount at any time.
+            </AlertDescription>
+          </AlertBox>
+        )}
+
         {stake === undefined ? (
           <BodyLg textAlign="center" mt="4">
             Loading stake data...


### PR DESCRIPTION
Closes: https://github.com/threshold-network/token-dashboard/issues/573

Aggregated authorization apps statuses into an `isFullyAuthorized` boolean indicating if the authorization process is fulfilled and used this boolean to conditionally render the `AlertBox` component.