### PR TITLE
Modify TVL labels

### DIFF
--- a/src/components/tBTC/Stats.tsx
+++ b/src/components/tBTC/Stats.tsx
@@ -15,7 +15,9 @@ export type TvlProps = {
 export const Tvl: FC<TvlProps> = ({ tvl, tvlInUSD }) => {
   return (
     <>
-      <BodyMd mb="1.5">TVL</BodyMd>
+      <BodyMd mb="1.5" textTransform="uppercase">
+        Total supply
+      </BodyMd>
       <H1 textAlign="center">
         <InlineTokenBalance tokenAmount={tvl} /> <H5 as="span">tBTC</H5>
       </H1>

--- a/src/pages/Overview/Network/TotalValueLocked.tsx
+++ b/src/pages/Overview/Network/TotalValueLocked.tsx
@@ -13,7 +13,7 @@ const TotalValueLocked: FC<{ totalValueLocked: number | string }> = ({
 
   return (
     <StatHighlightCard>
-      <StatHighlightTitle title={"total value locked"} />
+      <StatHighlightTitle title={"Total TVL (BTC + Staking)"} />
       <StatHighlightValue value={tvl} />
     </StatHighlightCard>
   )


### PR DESCRIPTION
Ref: https://github.com/threshold-network/token-dashboard/issues/589

Modified overview page sections labels:
- _TVL_ ➡️ _TOTAL SUPPLY_
- _TOTAL VALUE LOCKED_ ➡️ _TOTAL TVL (BTC + STAKING)_