### PR TITLE
Fix tbtc-v2.ts error after new update

### DIFF
--- a/src/tbtc/mock-bitcoin-client.ts
+++ b/src/tbtc/mock-bitcoin-client.ts
@@ -38,6 +38,7 @@ export const testnetUTXO: UnspentTransactionOutput & RawTransaction = {
   ...testnetTransaction,
 }
 const testnetPrivateKey = "cRJvyxtoggjAm9A94cB86hZ7Y62z2ei5VNJHLksFi2xdnz1GJ6xt"
+const fee = BigNumber.from(1520)
 
 export class MockBitcoinClient implements Client {
   private _unspentTransactionOutputs = new Map<
@@ -168,10 +169,12 @@ export class MockBitcoinClient implements Client {
       depositUtxo,
       rawTransaction: transaction,
     } = await assembleDepositTransaction(
+      network,
       deposit,
-      [testnetUTXO],
       testnetPrivateKey,
-      true
+      true,
+      [testnetUTXO],
+      fee
     )
 
     // mock second deposit transaction
@@ -192,10 +195,12 @@ export class MockBitcoinClient implements Client {
       depositUtxo: depositUtxo2,
       rawTransaction: transaction2,
     } = await assembleDepositTransaction(
+      network,
       deposit2,
-      [testnetUtxo2],
       testnetPrivateKey,
-      true
+      true,
+      [testnetUtxo2],
+      fee
     )
 
     const utxos = new Map<string, UnspentTransactionOutput[]>()


### PR DESCRIPTION
Ref: https://github.com/keep-network/tbtc-v2/pull/702

There was a change in https://github.com/keep-network/tbtc-v2/pull/702 in which we've added additional arguments to `assembleDepositTransaction` function. The order of the arguments was also changed. Because of that we couldn't build the project because we use that function in our dApp mock of the bitcoin client.

We are fixing this by passing two additional arguments to the `assembleDepositTransaction` function - `network` and `fee`. We are also making sure that we pass the arguments in the correct order.