### PR TITLE
Set tbtc-v2.ts lib back to development version

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ yarn upgrade @keep-network/coverage-pools@goerli \
   @keep-network/tbtc-v2@goerli \
   @keep-network/tbtc-v2.ts@goerli \
   @threshold-network/coverage-pools@npm:@keep-network/coverage-pools@goerli \
-  @threshold-network/solidity-contracts@goerli \
+  @threshold-network/solidity-contracts@goerli
 ```
 
 **NOTE 1:** We use the same Goerli versions for both

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@keep-network/random-beacon": "development",
     "@keep-network/tbtc": "development",
     "@keep-network/tbtc-v2": "development",
-    "@keep-network/tbtc-v2.ts": "development",
+    "@keep-network/tbtc-v2.ts": "1.3.0-dev.9",
     "@ledgerhq/connect-kit-loader": "^1.1.2",
     "@reduxjs/toolkit": "^1.6.1",
     "@rehooks/local-storage": "^2.4.4",

--- a/src/tbtc/mock-bitcoin-client.ts
+++ b/src/tbtc/mock-bitcoin-client.ts
@@ -38,7 +38,6 @@ export const testnetUTXO: UnspentTransactionOutput & RawTransaction = {
   ...testnetTransaction,
 }
 const testnetPrivateKey = "cRJvyxtoggjAm9A94cB86hZ7Y62z2ei5VNJHLksFi2xdnz1GJ6xt"
-const fee = BigNumber.from(1520)
 
 export class MockBitcoinClient implements Client {
   private _unspentTransactionOutputs = new Map<
@@ -169,12 +168,10 @@ export class MockBitcoinClient implements Client {
       depositUtxo,
       rawTransaction: transaction,
     } = await assembleDepositTransaction(
-      network,
       deposit,
-      testnetPrivateKey,
-      true,
       [testnetUTXO],
-      fee
+      testnetPrivateKey,
+      true
     )
 
     // mock second deposit transaction
@@ -195,12 +192,10 @@ export class MockBitcoinClient implements Client {
       depositUtxo: depositUtxo2,
       rawTransaction: transaction2,
     } = await assembleDepositTransaction(
-      network,
       deposit2,
-      testnetPrivateKey,
-      true,
       [testnetUtxo2],
-      fee
+      testnetPrivateKey,
+      true
     )
 
     const utxos = new Map<string, UnspentTransactionOutput[]>()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3193,10 +3193,10 @@
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@keep-network/tbtc-v2.ts@development":
-  version "1.3.0-dev.8"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.3.0-dev.8.tgz#08fb1a06dbe6d78a9c7b0d610363c68a135a6741"
-  integrity sha512-Y5fej8YhBbTZesE+87LNLHGt7I/G97f75J+15ieYyb2nqsJ/CcvMscIEAE/hNgxpnq4IWv/8qwYoldrHY4ix8w==
+"@keep-network/tbtc-v2.ts@1.3.0-dev.9":
+  version "1.3.0-dev.9"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-1.3.0-dev.9.tgz#b8961e2701ec1395da747269fea8cb6b236c4b77"
+  integrity sha512-cGtylB9Rc1Mltltl9NQJ1YKvTcs8HYTRRDsXlqf1VVtZcntngrl5Mu/OymuH84PlmpZpYMS95ZldEH9QoEMaeQ==
   dependencies:
     "@keep-network/ecdsa" "2.1.0-dev.15"
     "@keep-network/tbtc-v2" "1.6.0-dev.0"


### PR DESCRIPTION
We've decided that we actually don't have to apply the newest changes from `tbtc-v2.ts` yet, so we are reverting the changes made in https://github.com/threshold-network/token-dashboard/pull/640.

Besides that I've set `tbtc-v2.ts` version to `1.3.0-dev.9` in package.json. This is the closest dev version to the last goerli version (which is `1.3.0-goerli.1`. There is a newer one - `1.4.0-goerli.0`, but it will be deprecated).

This should fix all the issues with github workflows without the need to update `goerli` version of the `tbtc-v2.ts` lib.

Additionally I've removed an unnecessary slash in README - 6a017af9a2804dfcdd9dd421e734bc5077987245