### PR TITLE
Inadequate network parameter for address validation utility function

### DIFF
--- a/src/threshold-ts/tbtc/index.ts
+++ b/src/threshold-ts/tbtc/index.ts
@@ -1041,7 +1041,7 @@ export class TBTC implements ITBTC {
     return (
       !isValidBtcAddress(btcAddress, network) ||
       (!isPublicKeyHashTypeAddress(btcAddress, network) &&
-        !isPayToScriptHashTypeAddress(btcAddress))
+        !isPayToScriptHashTypeAddress(btcAddress, network))
     )
   }
 

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -106,7 +106,7 @@ export const validateUnmintBTCAddress = (
   } else if (
     !isValidBtcAddress(address, network) ||
     (!isPublicKeyHashTypeAddress(address, network) &&
-      !isPayToScriptHashTypeAddress(address))
+      !isPayToScriptHashTypeAddress(address, network))
   ) {
     return `The BTC address has to start with ${getBridgeBTCSupportedAddressPrefixesText(
       "unmint",


### PR DESCRIPTION
There is an error with redemption validation function caused by the network parameter which fallbacks to mainnet on a testnet when is not provided.