### PR TITLE
Improve Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ instead of `git://` by executing:
 git config --global url."https://".insteadOf git://
 ```
 
+**Sepolia-dev contracts**
+
+Ref: https://github.com/keep-network/tbtc-v2/pull/403
+
+Instead of the goerli contracts above you can also use `dapp-development-sepolia` contracts. They offer shorter durations for some specific elements in the contracts in comparison to goerli/mainnet and also allow to manually control mint and unmint process of tbtc-v2 (for more information see please see https://github.com/keep-network/tbtc-v2/pull/403) To install sepolia-dev contracts run:
+
+```
+yarn upgrade @keep-network/coverage-pools@sepolia \
+  @keep-network/keep-core@sepolia \
+  @keep-network/keep-ecdsa@sepolia \
+  @keep-network/random-beacon@dapp-development-sepolia \
+  @keep-network/tbtc@sepolia \
+  @threshold-network/coverage-pools@npm:@keep-network/coverage-pools@sepolia \
+  @threshold-network/solidity-contracts@dapp-development-sepolia
+```
+
+and set the `REACT_APP_DAPP_DEVELOPMENT_TESTNET_CONTRACTS` variable in `.env` file to true:
+
+```
+(...)
+REACT_APP_DAPP_DEVELOPMENT_TESTNET_CONTRACTS=true
+(...)
+```
+
 ## Run T dapp
 
 `yarn start`

--- a/README.md
+++ b/README.md
@@ -6,41 +6,6 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-# Local development
-
-## Prerequisites
-
-- Make sure your local chain is running (e.g. Ganache) and all repos listed below are cloned to the same folder (e.g. `threshold-network`).
-- Clone https://github.com/keep-network/keep-core repo:
-  - Make sure the `local` network config in [`/solidity-v1/truffle-config.js`](https://github.com/keep-network/keep-core/blob/main/solidity-v1/truffle-config.js#L8-L11) is correct for your chain.
-- Clone https://github.com/threshold-network/solidity-contracts repo:
-  - Make sure the `development` network config in [`hardhat.config.ts`](https://github.com/threshold-network/solidity-contracts/blob/main/hardhat.config.ts#L42-L44) is correct for your chain.
-- Clone https://github.com/keep-network/keep-ecdsa repo:
-  - Make sure the `local` network config in [`/solidity/truffle.js`](https://github.com/keep-network/keep-ecdsa/blob/main/solidity/truffle.js#L30-L35) is correct for your chain.
-- Clone https://github.com/keep-network/tbtc repo:
-  - Make sure the `development` network config in [`/solidity/truffle-config.js`](https://github.com/keep-network/tbtc/blob/main/solidity/truffle-config.js#L54-L58) is correct for your chain.
-- Clone https://github.com/keep-network/coverage-pools repo:
-  - Make sure the `development` network config in [`/hardhat.config.ts`](https://github.com/keep-network/coverage-pools/blob/main/hardhat.config.ts#L37-L41) is correct for your chain.
-- Clone https://github.com/threshold-network/components repo
-
-## Setup
-
-`yarn`
-
-## Deploy contracts and run dapp
-
-`yarn start:dev`
-
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-**Note:** if you need re run T dapp and all necessary contracts are deployed use `yarn start:dev -m`
-
-## Recompile `components` repo
-
-To make sure the changes made in local depository of `components` lib are implemented in T dapp you should recompile the lib using:
-
-`yarn add-components-lib`
-
 # Run T dapp against the Sepolia network
 
 ## Update the `.env` file:
@@ -62,12 +27,10 @@ REACT_APP_MULTICALL_ADDRESS=$MULTICALL_ADDRESS
 
 ```
 yarn upgrade @keep-network/coverage-pools@sepolia \
-  @keep-network/ecdsa@sepolia \
   @keep-network/keep-core@sepolia \
   @keep-network/keep-ecdsa@sepolia \
   @keep-network/random-beacon@sepolia \
   @keep-network/tbtc@sepolia \
-  @keep-network/tbtc-v2@sepolia \
   @threshold-network/coverage-pools@npm:@keep-network/coverage-pools@sepolia \
   @threshold-network/solidity-contracts@sepolia
 ```


### PR DESCRIPTION
Main changes:
- Removes `@keep-network/ecdsa@sepolia` and `@keep-network/tbtc-v2@sepolia` from `## Install Sepolia contracts` command, because we don't use those libs anymore,
- Removes outdated `# Local development` section,
- Adds `Sepolia-dev contracts` subsection 