### PR TITLE
Fix application status error on stake details page

### DIFF
--- a/src/pages/Staking/StakeDetailsPage/index.tsx
+++ b/src/pages/Staking/StakeDetailsPage/index.tsx
@@ -30,6 +30,7 @@ import { useAppDispatch, useAppSelector } from "../../../hooks/store"
 import { useWeb3React } from "@web3-react/core"
 import { AddressZero } from "@ethersproject/constants"
 import { isAddress } from "../../../web3/utils"
+import { stakingApplicationsSlice } from "../../../store/staking-applications"
 
 const StakeDetailsPage: FC = () => {
   const { stakingProviderAddress } = useParams()
@@ -40,6 +41,10 @@ const StakeDetailsPage: FC = () => {
   useEffect(() => {
     if (!isAddress(stakingProviderAddress!)) navigate(`/staking`)
   }, [stakingProviderAddress, navigate])
+
+  useEffect(() => {
+    dispatch(stakingApplicationsSlice.actions.getSupportedApps({}))
+  }, [dispatch])
 
   useEffect(() => {
     dispatch(


### PR DESCRIPTION
There was a bug that caused inaccuracies in the statuses of the tbtc and random beacon apps on the stake detail page. When you refresh the details page for a stake that the apps were not authorized for, it incorrectly displays them as authorized. This issue resolves itself when you navigate to the authorization or staking page and then return to the details page.

The issue arises from the fact that we did not dispatch the `getSupportedApps` action on the detail page. Consequently, the `getSupportedAppsEffect` was not triggered, leading to the `minimumAuthorization` value being set to 0 in the `selectStakingAppByStakingProvider` selector. This results in the `isAuthorized` flag being set to false.