### PR TITLE
Correct the BTC amount displayed in initiate mint

### DIFF
--- a/src/pages/tBTC/Bridge/Minting/InitiateMinting.tsx
+++ b/src/pages/tBTC/Bridge/Minting/InitiateMinting.tsx
@@ -61,19 +61,25 @@ const InitiateMintingComponent: FC<{
       />
       <InfoBox variant="modal" mb="6">
         <H5 mb={4}>
-          You deposited&nbsp;
+          You deposited{" "}
           <Skeleton isLoaded={!!depositedAmount} maxW="105px" as="span">
             <InlineTokenBalance
-              tokenAmount={depositedAmount.toString()}
               tokenSymbol="BTC"
+              tokenDecimals={8}
+              precision={6}
+              higherPrecision={8}
+              tokenAmount={depositedAmount.toString()}
+              displayTildeBelow={0}
               withSymbol
-            />
-          </Skeleton>
-          &nbsp;and will receive&nbsp;
+            />{" "}
+          </Skeleton>{" "}
+          and will receive{" "}
           <Skeleton isLoaded={!!tBTCMintAmount} maxW="105px" as="span">
             <InlineTokenBalance
               tokenAmount={tBTCMintAmount}
               tokenSymbol="tBTC"
+              precision={6}
+              higherPrecision={8}
               withSymbol
             />
           </Skeleton>


### PR DESCRIPTION
The wei amount, that user send to deposit address, was wrongly converted to BTC amount in InitiateMinting component. The value was converted to token amount as if it was wei instead of satoshi. Because of that it was converted to a really small value.