### PR TITLE
Fix typos

### DIFF
--- a/src/components/Modal/TopupTModal/LegacyTopUpModal.tsx
+++ b/src/components/Modal/TopupTModal/LegacyTopUpModal.tsx
@@ -119,7 +119,7 @@ const LegacyTopUpModal: FC<BaseModalProps & { stake: StakeData }> = ({
                   <AlertDescription
                     color={useColorModeValue("gray.700", "gray.300")}
                   >
-                    After you topped-up in the legacy dashboad you will need to
+                    After you topped-up in the legacy dashboard you will need to
                     confirm your top-up in the Threshold Dashboard. This action
                     will require one transaction.
                   </AlertDescription>

--- a/src/pages/tBTC/Bridge/Minting/InitiateMinting.tsx
+++ b/src/pages/tBTC/Bridge/Minting/InitiateMinting.tsx
@@ -88,7 +88,7 @@ const InitiateMintingComponent: FC<{
           </Skeleton>
         </H5>
         <BodyLg>
-          Receiving tBTC requires a single transaction on Solana and takes
+          Receiving tBTC requires a single transaction on Ethereum and takes
           approximately 2 hours. The bridging can be initiated before you get
           all your Bitcoin deposit confirmations.
         </BodyLg>


### PR DESCRIPTION
`Solana` -> `Ethereum`
`dashboad` -> `dashboard`