### PR TITLE
Update @ledgerhq/connect-kit-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@keep-network/random-beacon": "development",
     "@keep-network/tbtc": "development",
     "@keep-network/tbtc-v2.ts": "^2.3.0",
-    "@ledgerhq/connect-kit-loader": "^1.1.2",
+    "@ledgerhq/connect-kit-loader": "1.1.8",
     "@ledgerhq/wallet-api-client": "^1.2.0",
     "@ledgerhq/wallet-api-client-react": "^1.1.1",
     "@reduxjs/toolkit": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,10 +3494,10 @@
     "@summa-tx/relay-sol" "^2.0.2"
     openzeppelin-solidity "2.3.0"
 
-"@ledgerhq/connect-kit-loader@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz#d550e3c1f046e4c796f32a75324b03606b7e226a"
-  integrity sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A==
+"@ledgerhq/connect-kit-loader@1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.8.tgz#6cc32191660dd9d6e8f89047af09b0f201e30190"
+  integrity sha512-mDJsOucVW8m3Lk2fdQst+P74SgiKebvq1iBk4sXLbADQOwhL9bWGaArvO+tW7jPJZwEfSPWBdHcHoYi11XAwZw==
 
 "@ledgerhq/cryptoassets@^5.53.0":
   version "5.53.0"


### PR DESCRIPTION
Update the `@ledgerhq/connect-kit-loader` dependency to `1.1.8` so that it is tethered to version 1.1.8 of the connect-kit.