### PR TITLE
Update actions to versions running on Node20

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v6
         with:
           build: yarn build
           start: yarn start

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -25,9 +25,9 @@ jobs:
     name: Check code format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "yarn"
@@ -54,9 +54,9 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "yarn"

--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -13,9 +13,9 @@ jobs:
     name: Build for mainnet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "yarn"
@@ -78,7 +78,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.MAINNET_SENTRY_DSN }}
           WALLET_CONNECT_PROJECT_ID: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build
           path: build
@@ -89,9 +89,9 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Deploy PR mainnet preview to GCP
         # Temporarily we run the action in version from `alpine-version-413.0.0`
@@ -115,9 +115,9 @@ jobs:
       name: mainnet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Deploy mainnet build to GCP
         # Temporarily we run the action in version from `alpine-version-413.0.0`

--- a/.github/workflows/reusable-build-and-publish.yml
+++ b/.github/workflows/reusable-build-and-publish.yml
@@ -83,9 +83,9 @@ jobs:
     environment: ${{ inputs.requireApproval && 'protected' || '' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "yarn"
@@ -205,7 +205,7 @@ jobs:
 
       - name: Post preview URL to PR
         if: inputs.preview == true
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({


### PR DESCRIPTION
As per
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/, GitHub has started a deprecation process for the GitHub Actions that run on Node16. We're updating Actions that use this version of Node to newer versions, running on Node20.