### PR TITLE
Document the code after Goerli deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git config --global url."https://".insteadOf git://
 
 Ref: https://github.com/keep-network/tbtc-v2/pull/403
 
-Instead of the goerli contracts above you can also use `dapp-development-sepolia` contracts. They offer shorter durations for some specific elements in the contracts in comparison to goerli/mainnet and also allow to manually control mint and unmint process of tbtc-v2 (for more information see please see https://github.com/keep-network/tbtc-v2/pull/403) To install sepolia-dev contracts run:
+Instead of the `sepolia` contracts above you can also use `dapp-development-sepolia` contracts. They offer shorter durations for some specific elements in the contracts in comparison to `sepolia`/`mainnet` and also allow to manually control mint and unmint process of `tbtc-v2` (for more information see please see https://github.com/keep-network/tbtc-v2/pull/403). To install sepolia-dev contracts run:
 
 ```
 yarn @keep-network/keep-core@sepolia \

--- a/src/hooks/ledger-live-app/useRequestEthereumAccount.ts
+++ b/src/hooks/ledger-live-app/useRequestEthereumAccount.ts
@@ -44,6 +44,9 @@ export function useRequestEthereumAccount(): UseRequestAccountReturn {
   }, [account, isEmbed])
 
   const requestEthereumAccount = useCallback(async () => {
+    // The Goerli testnet become deprecated. However, we did not test Ledger
+    // Live on Sepolia yet, so we're leaving the Goerli config for now in the
+    // code.
     const currencyId = supportedChainId === "1" ? "ethereum" : "ethereum_goerli"
     walletApiReactTransport.connect()
     await requestAccount({ currencyIds: [currencyId] })


### PR DESCRIPTION
The Goerli testnet got deprecated with end of 2023. It's still running at the beginning of 2024, but it may be unreliable. In earlier PRs we've changed the most of the testnet-related code to use the Sepolia testnet. In this PR we're adding a comment about Goerli deprecation to the fragment of code that still references Goerli and we may want to update in the future. We're also fixing a typo in the README related to the Goerli -> Sepolia migration.