### PR TITLE
Implement minting and unminting funnels in posthog

### DIFF
--- a/src/components/Modal/SelectWalletModal/ConnectCoinbase.tsx
+++ b/src/components/Modal/SelectWalletModal/ConnectCoinbase.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react"
 import { useWeb3React } from "@web3-react/core"
 import { WalletConnectionModalBase } from "./components"
-import { ConnectionError, WalletType } from "../../../enums"
+import { ConnectionError } from "../../../enums"
 import { coinbaseConnector } from "../../../web3/connectors"
 import CoinbaseStatusAlert from "./components/CoinbaseStatusAlert"
 import { CoinbaseWallet } from "../../../static/icons/CoinbaseWallet"
@@ -34,7 +34,6 @@ const ConnectCoinbase: FC<{ goBack: () => void; closeModal: () => void }> = ({
       tryAgain={
         connectionRejected ? () => activate(coinbaseConnector) : undefined
       }
-      walletType={WalletType.Coinbase}
     >
       <CoinbaseStatusAlert
         connectionRejected={connectionRejected}

--- a/src/components/Modal/SelectWalletModal/ConnectLedgerLive.tsx
+++ b/src/components/Modal/SelectWalletModal/ConnectLedgerLive.tsx
@@ -2,7 +2,7 @@ import { FC } from "react"
 import { useWeb3React } from "@web3-react/core"
 import { ledgerLive } from "../../../web3/connectors"
 import { WalletConnectionModalBase } from "./components"
-import { ConnectionError, WalletType } from "../../../enums"
+import { ConnectionError } from "../../../enums"
 import doesErrorInclude from "../../../web3/utils/doesErrorInclude"
 import { LedgerLight } from "../../../static/icons/LedgerLight"
 import { LedgerDark } from "../../../static/icons/LedgerDark"
@@ -34,7 +34,6 @@ const ConnectLedgerLive: FC<{ goBack: () => void; closeModal: () => void }> = ({
           : ""
       }
       tryAgain={connectionRejected ? () => activate(ledgerLive) : undefined}
-      walletType={WalletType.LedgerLive}
       shouldForceCloseModal
     />
   )

--- a/src/components/Modal/SelectWalletModal/ConnectMetamask.tsx
+++ b/src/components/Modal/SelectWalletModal/ConnectMetamask.tsx
@@ -6,7 +6,7 @@ import {
   metamask,
 } from "../../../web3/connectors"
 import { MetamaskStatusAlert, WalletConnectionModalBase } from "./components"
-import { ConnectionError, WalletType } from "../../../enums"
+import { ConnectionError } from "../../../enums"
 import doesErrorInclude from "../../../web3/utils/doesErrorInclude"
 
 const ConnectMetamask: FC<{ goBack: () => void; closeModal: () => void }> = ({
@@ -38,7 +38,6 @@ const ConnectMetamask: FC<{ goBack: () => void; closeModal: () => void }> = ({
         !error ? "The MetaMask extension will open in an external window." : ""
       }
       tryAgain={connectionRejected ? () => activate(metamask) : undefined}
-      walletType={WalletType.Metamask}
     >
       <MetamaskStatusAlert
         metamaskNotInstalled={metamaskNotInstalled}

--- a/src/components/Modal/SelectWalletModal/ConnectTaho.tsx
+++ b/src/components/Modal/SelectWalletModal/ConnectTaho.tsx
@@ -18,7 +18,7 @@ import {
   WalletInitializeAlert,
   WalletRejectedAlert,
 } from "./components"
-import { ExternalHref, WalletType } from "../../../enums"
+import { ExternalHref } from "../../../enums"
 import Link from "../../Link"
 
 const ConnectTaho: FC<{ goBack: () => void; closeModal: () => void }> = ({
@@ -59,7 +59,6 @@ const ConnectTaho: FC<{ goBack: () => void; closeModal: () => void }> = ({
             }
           : undefined
       }
-      walletType={WalletType.TAHO}
     >
       {isTahoNotInstalled && <InstallTaho />}
       {isTahoNotDefaultWallet && <TahoIsNotSetAsDefaultWallet />}

--- a/src/components/Modal/SelectWalletModal/ConnectWalletConnect.tsx
+++ b/src/components/Modal/SelectWalletModal/ConnectWalletConnect.tsx
@@ -5,7 +5,7 @@ import {
   WalletConnectionModalBase,
   WalletConnectStatusAlert,
 } from "./components"
-import { ConnectionError, WalletType } from "../../../enums"
+import { ConnectionError } from "../../../enums"
 import doesErrorInclude from "../../../web3/utils/doesErrorInclude"
 import { walletConnect } from "../../../web3/connectors/walletConnect"
 
@@ -35,7 +35,6 @@ const ConnectWalletConnect: FC<{
         walletConnect.provider = undefined
         activate(walletConnect)
       }}
-      walletType={WalletType.WalletConnect}
       shouldForceCloseModal
     >
       <WalletConnectStatusAlert

--- a/src/components/Modal/SelectWalletModal/components/WalletConnectionModalBase.tsx
+++ b/src/components/Modal/SelectWalletModal/components/WalletConnectionModalBase.tsx
@@ -15,8 +15,6 @@ import { BaseModalProps } from "../../../../types"
 import { BodyMd, H4 } from "@threshold-network/components"
 import { AbstractConnector } from "../../../../web3/connectors"
 import { WalletType } from "../../../../enums"
-import { useCapture } from "../../../../hooks/posthog"
-import { PosthogEvent } from "../../../../types/posthog"
 
 interface Props extends BaseModalProps {
   WalletIcon: any
@@ -26,7 +24,6 @@ interface Props extends BaseModalProps {
   onContinue?: () => void
   goBack: () => void
   connector?: AbstractConnector
-  walletType: WalletType
   /**
    * This is required for some of the providers (for example WalletConnect v2),
    * because they have their own modal that is being opened. In that case we
@@ -47,25 +44,16 @@ const WalletConnectionModalBase: FC<Props> = ({
   tryAgain,
   onContinue,
   connector,
-  walletType,
   shouldForceCloseModal,
 }) => {
   const { activate, active, account } = useWeb3React()
-  const captureWalletConnected = useCapture(PosthogEvent.WalletConnected)
 
   useEffect(() => {
     if (!connector) return
 
-    captureWalletConnected({ walletType })
     activate(connector)
     if (shouldForceCloseModal) closeModal()
-  }, [
-    activate,
-    connector,
-    captureWalletConnected,
-    walletType,
-    shouldForceCloseModal,
-  ])
+  }, [activate, connector, shouldForceCloseModal])
 
   return (
     <>

--- a/src/components/Modal/tBTC/InitiateUnminting.tsx
+++ b/src/components/Modal/tBTC/InitiateUnminting.tsx
@@ -134,7 +134,7 @@ const InitiateUnmintingBase: FC<InitiateUnmintingProps> = ({
             PosthogButtonId.InitiateUnminting
           }
           data-ph-capture-attribute-button-text={"Unmint"}
-          data-ph-capture-attribute-unminted-amount={unmintAmount}
+          data-ph-capture-attribute-unminted-tbtc-amount={unmintAmount}
         >
           Unmint
         </Button>

--- a/src/components/Modal/tBTC/InitiateUnminting.tsx
+++ b/src/components/Modal/tBTC/InitiateUnminting.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../TransactionDetails"
 import ModalCloseButton from "../ModalCloseButton"
 import withBaseModal from "../withBaseModal"
+import { PosthogButtonId } from "../../../types/posthog"
 
 type InitiateUnmintingProps = {
   unmintAmount: string
@@ -126,7 +127,17 @@ const InitiateUnmintingBase: FC<InitiateUnmintingProps> = ({
         <Button onClick={closeModal} variant="outline" mr={2}>
           Cancel
         </Button>
-        <Button onClick={initiateUnminting}>Unmint</Button>
+        <Button
+          onClick={initiateUnminting}
+          data-ph-capture-attribute-button-name={"Unmint (Modal)"}
+          data-ph-capture-attribute-button-id={
+            PosthogButtonId.InitiateUnminting
+          }
+          data-ph-capture-attribute-button-text={"Unmint"}
+          data-ph-capture-attribute-unminted-amount={unmintAmount}
+        >
+          Unmint
+        </Button>
       </ModalFooter>
     </>
   )

--- a/src/components/Navbar/AccountButton.tsx
+++ b/src/components/Navbar/AccountButton.tsx
@@ -13,10 +13,12 @@ const AccountButton: FC<{
   deactivate: () => void
 }> = ({ openWalletModal, account, deactivate }) => {
   const dispatch = useAppDispatch()
-  const captureWalletDisconnected = useCapture(PosthogEvent.WalletDisconnected)
+  const captureWalletDisconnectedEvent = useCapture(
+    PosthogEvent.WalletDisconnected
+  )
 
   const onDisconnectClick = () => {
-    captureWalletDisconnected()
+    captureWalletDisconnectedEvent()
     dispatch(resetStoreAction())
     deactivate()
   }

--- a/src/components/Navbar/AccountButton.tsx
+++ b/src/components/Navbar/AccountButton.tsx
@@ -1,7 +1,9 @@
 import { Button, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react"
 import { FC } from "react"
+import { useCapture } from "../../hooks/posthog"
 import { useAppDispatch } from "../../hooks/store"
 import { resetStoreAction } from "../../store"
+import { PosthogEvent } from "../../types/posthog"
 import shortenAddress from "../../utils/shortenAddress"
 import Identicon from "../Identicon"
 
@@ -11,8 +13,10 @@ const AccountButton: FC<{
   deactivate: () => void
 }> = ({ openWalletModal, account, deactivate }) => {
   const dispatch = useAppDispatch()
+  const captureWalletDisconnected = useCapture(PosthogEvent.WalletDisconnected)
 
   const onDisconnectClick = () => {
+    captureWalletDisconnected()
     dispatch(resetStoreAction())
     deactivate()
   }

--- a/src/contexts/TokenContext.tsx
+++ b/src/contexts/TokenContext.tsx
@@ -47,6 +47,8 @@ export const TokenContextProvider: React.FC = ({ children }) => {
     fetchTokenPriceUSD,
     setTokenBalance,
     setTokenConversionRate,
+    setTokenLoading,
+    setTokenIsLoadedFromConnectedAccount,
     keep: keepData,
     nu: nuData,
     t: tData,
@@ -88,13 +90,28 @@ export const TokenContextProvider: React.FC = ({ children }) => {
   //
   React.useEffect(() => {
     if (isActive) {
+      setTokenLoading(Token.Keep, true)
+      setTokenLoading(Token.Nu, true)
+      setTokenLoading(Token.T, true)
+      setTokenLoading(Token.TBTCV2, true)
       fetchBalances().then(
         ([keepBalance, nuBalance, tBalance, tbtcv2Balance]) => {
           setTokenBalance(Token.Keep, keepBalance.toString())
+          setTokenLoading(Token.Keep, false)
+          setTokenIsLoadedFromConnectedAccount(Token.Keep, true)
+
           setTokenBalance(Token.Nu, nuBalance.toString())
+          setTokenLoading(Token.Nu, false)
+          setTokenIsLoadedFromConnectedAccount(Token.Nu, true)
+
           setTokenBalance(Token.T, tBalance.toString())
+          setTokenLoading(Token.T, false)
+          setTokenIsLoadedFromConnectedAccount(Token.T, true)
+
           if (featureFlags.TBTC_V2) {
             setTokenBalance(Token.TBTCV2, tbtcv2Balance.toString())
+            setTokenLoading(Token.TBTCV2, false)
+            setTokenIsLoadedFromConnectedAccount(Token.TBTCV2, true)
           }
         }
       )
@@ -102,8 +119,11 @@ export const TokenContextProvider: React.FC = ({ children }) => {
       // set all token balances to 0 if the user disconnects the wallet
       for (const token in Token) {
         if (token) {
-          // @ts-ignore
-          setTokenBalance(Token[token], 0)
+          const key = token as keyof typeof Token
+          setTokenLoading(Token[key], true)
+          setTokenBalance(Token[key], 0)
+          setTokenLoading(Token[key], false)
+          setTokenIsLoadedFromConnectedAccount(Token[key], false)
         }
       }
     }

--- a/src/hooks/posthog/useCapture.ts
+++ b/src/hooks/posthog/useCapture.ts
@@ -5,7 +5,7 @@ import * as posthog from "../../posthog"
 
 export const useCapture = (eventName: PosthogEvent) => {
   return useCallback(
-    (params) => {
+    (params?) => {
       if (!featureFlags.POSTHOG) return
       posthog.capture(eventName, params)
     },

--- a/src/hooks/posthog/useCaptureWalletConnected.ts
+++ b/src/hooks/posthog/useCaptureWalletConnected.ts
@@ -1,0 +1,29 @@
+import { useWeb3React } from "@web3-react/core"
+import { useEffect } from "react"
+import { Token } from "../../enums"
+import { PosthogEvent } from "../../types/posthog"
+import { getWalletTypeFromConnector } from "../../web3/utils/connectors"
+import { useToken } from "../useToken"
+import { useCapture } from "./useCapture"
+
+export const useCaptureWalletConnected = () => {
+  const { account, connector } = useWeb3React()
+  const { balance, loading, isLoadedFromConnectedAccount } = useToken(
+    Token.TBTCV2
+  )
+  const captureWalletConnected = useCapture(PosthogEvent.WalletConnected)
+
+  useEffect(() => {
+    // Capture posthog wallet connected event only if account is connected AND
+    // when TBTCV2 token balance is fetched for this account.
+    if (account && connector && !loading && isLoadedFromConnectedAccount) {
+      const walletType = getWalletTypeFromConnector(connector)
+      const posthogData = {
+        walletType,
+        address: account,
+        tbtcBalance: balance,
+      }
+      captureWalletConnected(posthogData)
+    }
+  }, [account, connector, balance, loading, isLoadedFromConnectedAccount])
+}

--- a/src/hooks/posthog/useCaptureWalletConnected.ts
+++ b/src/hooks/posthog/useCaptureWalletConnected.ts
@@ -9,7 +9,7 @@ import { useCapture } from "./useCapture"
 export const useCaptureWalletConnected = () => {
   const { account, connector } = useWeb3React()
   const { balance, isLoadedFromConnectedAccount } = useToken(Token.TBTCV2)
-  const captureWalletConnected = useCapture(PosthogEvent.WalletConnected)
+  const captureWalletConnectedEvent = useCapture(PosthogEvent.WalletConnected)
 
   useEffect(() => {
     // Capture posthog wallet connected event only if account is connected AND
@@ -21,7 +21,7 @@ export const useCaptureWalletConnected = () => {
         address: account,
         tbtcBalance: balance,
       }
-      captureWalletConnected(posthogData)
+      captureWalletConnectedEvent(posthogData)
     }
   }, [account, connector, balance, isLoadedFromConnectedAccount])
 }

--- a/src/hooks/posthog/useCaptureWalletConnected.ts
+++ b/src/hooks/posthog/useCaptureWalletConnected.ts
@@ -8,15 +8,13 @@ import { useCapture } from "./useCapture"
 
 export const useCaptureWalletConnected = () => {
   const { account, connector } = useWeb3React()
-  const { balance, loading, isLoadedFromConnectedAccount } = useToken(
-    Token.TBTCV2
-  )
+  const { balance, isLoadedFromConnectedAccount } = useToken(Token.TBTCV2)
   const captureWalletConnected = useCapture(PosthogEvent.WalletConnected)
 
   useEffect(() => {
     // Capture posthog wallet connected event only if account is connected AND
     // when TBTCV2 token balance is fetched for this account.
-    if (account && connector && !loading && isLoadedFromConnectedAccount) {
+    if (account && connector && isLoadedFromConnectedAccount) {
       const walletType = getWalletTypeFromConnector(connector)
       const posthogData = {
         walletType,
@@ -25,5 +23,5 @@ export const useCaptureWalletConnected = () => {
       }
       captureWalletConnected(posthogData)
     }
-  }, [account, connector, balance, loading, isLoadedFromConnectedAccount])
+  }, [account, connector, balance, isLoadedFromConnectedAccount])
 }

--- a/src/hooks/posthog/useCaptureWalletConnectedEvent.ts
+++ b/src/hooks/posthog/useCaptureWalletConnectedEvent.ts
@@ -6,7 +6,7 @@ import { getWalletTypeFromConnector } from "../../web3/utils/connectors"
 import { useToken } from "../useToken"
 import { useCapture } from "./useCapture"
 
-export const useCaptureWalletConnected = () => {
+export const useCaptureWalletConnectedEvent = () => {
   const { account, connector } = useWeb3React()
   const { balance, isLoadedFromConnectedAccount } = useToken(Token.TBTCV2)
   const captureWalletConnectedEvent = useCapture(PosthogEvent.WalletConnected)

--- a/src/hooks/posthog/usePosthog.ts
+++ b/src/hooks/posthog/usePosthog.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react"
 import { featureFlags } from "../../constants"
 import * as posthog from "../../posthog"
 import { useCapturePageview } from "./useCapturePageview"
-import { useCaptureWalletConnected } from "./useCaptureWalletConnected"
+import { useCaptureWalletConnectedEvent } from "./useCaptureWalletConnectedEvent"
 import { useIdentify } from "./useIdentify"
 
 export const usePosthog = () => {
@@ -14,5 +14,5 @@ export const usePosthog = () => {
 
   useCapturePageview()
   useIdentify()
-  useCaptureWalletConnected()
+  useCaptureWalletConnectedEvent()
 }

--- a/src/hooks/posthog/usePosthog.ts
+++ b/src/hooks/posthog/usePosthog.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react"
 import { featureFlags } from "../../constants"
 import * as posthog from "../../posthog"
 import { useCapturePageview } from "./useCapturePageview"
+import { useCaptureWalletConnected } from "./useCaptureWalletConnected"
 import { useIdentify } from "./useIdentify"
 
 export const usePosthog = () => {
@@ -13,4 +14,5 @@ export const usePosthog = () => {
 
   useCapturePageview()
   useIdentify()
+  useCaptureWalletConnected()
 }

--- a/src/hooks/useSaveConnectedAddressToStore.ts
+++ b/src/hooks/useSaveConnectedAddressToStore.ts
@@ -22,7 +22,7 @@ export const useSaveConnectedAddressToStore = () => {
         walletType,
         account,
       }
-      // captureWalletConnected(posthogData)
+      captureWalletConnected(posthogData)
     }
   }, [account, connector])
 }

--- a/src/hooks/useSaveConnectedAddressToStore.ts
+++ b/src/hooks/useSaveConnectedAddressToStore.ts
@@ -2,27 +2,13 @@ import { useWeb3React } from "@web3-react/core"
 import { useEffect } from "react"
 import { useDispatch } from "react-redux"
 import { walletConnected } from "../store/account"
-import { PosthogEvent } from "../types/posthog"
-import { getWalletTypeFromConnector } from "../web3/utils/connectors"
-import { useCapture } from "./posthog"
 
 export const useSaveConnectedAddressToStore = () => {
-  const { account, connector } = useWeb3React()
+  const { account } = useWeb3React()
   const dispatch = useDispatch()
-  const captureWalletConnected = useCapture(PosthogEvent.WalletConnected)
 
   useEffect(() => {
     const address = account ? account : ""
     dispatch(walletConnected(address))
-
-    // Capture posthog wallet connected event
-    if (account && connector) {
-      const walletType = getWalletTypeFromConnector(connector)
-      const posthogData = {
-        walletType,
-        account,
-      }
-      captureWalletConnected(posthogData)
-    }
-  }, [account, connector])
+  }, [account])
 }

--- a/src/hooks/useSaveConnectedAddressToStore.ts
+++ b/src/hooks/useSaveConnectedAddressToStore.ts
@@ -2,13 +2,27 @@ import { useWeb3React } from "@web3-react/core"
 import { useEffect } from "react"
 import { useDispatch } from "react-redux"
 import { walletConnected } from "../store/account"
+import { PosthogEvent } from "../types/posthog"
+import { getWalletTypeFromConnector } from "../web3/utils/connectors"
+import { useCapture } from "./posthog"
 
 export const useSaveConnectedAddressToStore = () => {
-  const { account } = useWeb3React()
+  const { account, connector } = useWeb3React()
   const dispatch = useDispatch()
+  const captureWalletConnected = useCapture(PosthogEvent.WalletConnected)
 
   useEffect(() => {
     const address = account ? account : ""
     dispatch(walletConnected(address))
-  }, [account])
+
+    // Capture posthog wallet connected event
+    if (account && connector) {
+      const walletType = getWalletTypeFromConnector(connector)
+      const posthogData = {
+        walletType,
+        account,
+      }
+      // captureWalletConnected(posthogData)
+    }
+  }, [account, connector])
 }

--- a/src/hooks/useTokenState.ts
+++ b/src/hooks/useTokenState.ts
@@ -2,6 +2,7 @@ import { useSelector, useDispatch } from "react-redux"
 import {
   setTokenBalance as setTokenBalanceAction,
   setTokenLoading as setTokenLoadingAction,
+  setTokenIsLoadedFromConnectedAccount as setTokenIsLoadedFromConnectedAccountAction,
   fetchTokenPriceUSD as fetchTokenPriceAction,
   setTokenConversionRate as setTokenConversionRateAction,
 } from "../store/tokens"
@@ -29,6 +30,17 @@ export const useTokenState: UseTokenState = () => {
   const setTokenLoading = (token: Token, loading: boolean) =>
     dispatch(setTokenLoadingAction({ token, loading }))
 
+  const setTokenIsLoadedFromConnectedAccount = (
+    token: Token,
+    isLoadedFromConnectedAccount: boolean
+  ) =>
+    dispatch(
+      setTokenIsLoadedFromConnectedAccountAction({
+        token,
+        isLoadedFromConnectedAccount,
+      })
+    )
+
   const fetchTokenPriceUSD = (token: Token) =>
     dispatch(fetchTokenPriceAction({ token }))
 
@@ -41,6 +53,7 @@ export const useTokenState: UseTokenState = () => {
     fetchTokenPriceUSD,
     setTokenBalance,
     setTokenLoading,
+    setTokenIsLoadedFromConnectedAccount,
     setTokenConversionRate,
   }
 }

--- a/src/pages/tBTC/Bridge/Minting/InitiateMinting.tsx
+++ b/src/pages/tBTC/Bridge/Minting/InitiateMinting.tsx
@@ -14,6 +14,7 @@ import { useThreshold } from "../../../../contexts/ThresholdContext"
 import { useRevealDepositTransaction } from "../../../../hooks/tbtc"
 import { Toast } from "../../../../components/Toast"
 import { useModal } from "../../../../hooks/useModal"
+import { PosthogButtonId } from "../../../../types/posthog"
 
 const InitiateMintingComponent: FC<{
   utxo: BitcoinUtxo
@@ -100,6 +101,9 @@ const InitiateMintingComponent: FC<{
         data-ph-capture-attribute-button-name={
           "Confirm deposit & mint (Step 2)"
         }
+        data-ph-capture-attribute-button-id={PosthogButtonId.InitiateMinting}
+        data-ph-capture-attribute-button-text={"Bridge"}
+        data-ph-capture-attribute-deposited-btc-amount={utxo.value}
       >
         Bridge
       </Button>

--- a/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
@@ -25,6 +25,7 @@ import { downloadFile, isSameETHAddress } from "../../../../web3/utils"
 import { BridgeProcessCardSubTitle } from "../components/BridgeProcessCardSubTitle"
 import { BridgeProcessCardTitle } from "../components/BridgeProcessCardTitle"
 import { useIsActive } from "../../../../hooks/useIsActive"
+import { PosthogButtonId } from "../../../../types/posthog"
 
 export interface FormValues {
   ethAddress: string
@@ -220,6 +221,10 @@ export const ProvideDataComponent: FC<{
         form="tbtc-minting-data-form"
         isFullWidth
         data-ph-capture-attribute-button-name={`Generate Deposit Address (Deposit flow)`}
+        data-ph-capture-attribute-button-id={
+          PosthogButtonId.GenerateDepositAddress
+        }
+        data-ph-capture-attribute-button-text={`Generate Deposit Address`}
       >
         Generate Deposit Address
       </Button>

--- a/src/posthog/index.ts
+++ b/src/posthog/index.ts
@@ -1,4 +1,4 @@
-import posthog from "posthog-js"
+import posthog, { Properties } from "posthog-js"
 import { EnvVariable } from "../enums"
 import { getEnvVariable } from "../utils/getEnvVariable"
 import { PosthogEvent } from "../types/posthog"
@@ -21,8 +21,12 @@ export const init = () => {
   })
 }
 
-export const identify = (ethAddress: string) => {
-  posthog.identify(ethAddress)
+export const identify = (
+  ethAddress: string,
+  userPropertiesToSet?: Properties,
+  userPropertiesToSetOnce?: Properties
+) => {
+  posthog.identify(ethAddress, userPropertiesToSet, userPropertiesToSetOnce)
 }
 
 // Posthog automatically sends pageview events whenever it gets loaded. For a

--- a/src/posthog/index.ts
+++ b/src/posthog/index.ts
@@ -43,7 +43,7 @@ export const reset = () => {
 
 export const capture = (
   event: PosthogEvent,
-  params: { [key: string]: unknown }
+  params?: { [key: string]: unknown }
 ) => {
   posthog.capture(event, params)
 }

--- a/src/store/tokens/tokenSlice.ts
+++ b/src/store/tokens/tokenSlice.ts
@@ -7,6 +7,7 @@ import {
   SetTokenBalanceActionPayload,
   SetTokenConversionRateActionPayload,
   SetTokenLoadingActionPayload,
+  SetTokenIsLoadedFromConnectedAccountActionPayload,
 } from "../../types/token"
 import { exchangeAPI } from "../../utils/exchangeAPI"
 import getUsdBalance from "../../utils/getUsdBalance"
@@ -34,6 +35,7 @@ export const tokenSlice = createSlice({
   initialState: {
     [Token.Keep]: {
       loading: false,
+      isLoadedFromConnectedAccount: false,
       balance: 0,
       conversionRate: 4.87,
       text: Token.Keep,
@@ -43,6 +45,7 @@ export const tokenSlice = createSlice({
     },
     [Token.Nu]: {
       loading: false,
+      isLoadedFromConnectedAccount: false,
       balance: 0,
       conversionRate: 2.66,
       text: Token.Nu,
@@ -52,6 +55,7 @@ export const tokenSlice = createSlice({
     },
     [Token.T]: {
       loading: false,
+      isLoadedFromConnectedAccount: false,
       balance: 0,
       conversionRate: 1,
       text: Token.T,
@@ -61,12 +65,14 @@ export const tokenSlice = createSlice({
     },
     [Token.TBTC]: {
       loading: false,
+      isLoadedFromConnectedAccount: false,
       balance: 0,
       usdConversion: 0,
       usdBalance: "0",
     },
     [Token.TBTCV2]: {
       loading: false,
+      isLoadedFromConnectedAccount: false,
       balance: 0,
       usdConversion: 0,
       usdBalance: "0",
@@ -78,6 +84,13 @@ export const tokenSlice = createSlice({
       action: PayloadAction<SetTokenLoadingActionPayload>
     ) => {
       state[action.payload.token].loading = action.payload.loading
+    },
+    setTokenIsLoadedFromConnectedAccount: (
+      state,
+      action: PayloadAction<SetTokenIsLoadedFromConnectedAccountActionPayload>
+    ) => {
+      state[action.payload.token].isLoadedFromConnectedAccount =
+        action.payload.isLoadedFromConnectedAccount
     },
     setTokenBalance: (
       state,
@@ -110,5 +123,9 @@ export const tokenSlice = createSlice({
   },
 })
 
-export const { setTokenBalance, setTokenLoading, setTokenConversionRate } =
-  tokenSlice.actions
+export const {
+  setTokenBalance,
+  setTokenLoading,
+  setTokenIsLoadedFromConnectedAccount,
+  setTokenConversionRate,
+} = tokenSlice.actions

--- a/src/types/posthog.ts
+++ b/src/types/posthog.ts
@@ -1,9 +1,11 @@
 export enum PosthogEvent {
   ClosedModal = "Closed Modal",
   WalletConnected = "Walled Connected",
+  WalletDisconnected = "Wallet Disconnected",
 }
 
 export enum PosthogButtonId {
   GenerateDepositAddress = "generate-deposit-address-button",
   InitiateMinting = "initiate-minting-button",
+  InitiateUnminting = "initiate-unminting-button",
 }

--- a/src/types/posthog.ts
+++ b/src/types/posthog.ts
@@ -2,3 +2,8 @@ export enum PosthogEvent {
   ClosedModal = "Closed Modal",
   WalletConnected = "Walled Connected",
 }
+
+export enum PosthogButtonId {
+  GenerateDepositAddress = "generate-deposit-address-button",
+  InitiateMinting = "initiate-minting-button",
+}

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -5,6 +5,7 @@ import { TokenIcon } from "../static/icons/tokenIconMap"
 
 export interface TokenState {
   loading: boolean
+  isLoadedFromConnectedAccount: boolean
   conversionRate: number | string
   text: string
   icon: TokenIcon
@@ -29,12 +30,21 @@ export interface SetTokenLoadingActionPayload {
   loading: boolean
 }
 
+export interface SetTokenIsLoadedFromConnectedAccountActionPayload {
+  token: Token
+  isLoadedFromConnectedAccount: boolean
+}
+
 export interface SetTokenBalance {
   payload: SetTokenBalanceActionPayload
 }
 
 export interface SetTokenLoading {
   payload: SetTokenLoadingActionPayload
+}
+
+export interface SetTokenIsLoadedFromConnectedAccount {
+  payload: SetTokenIsLoadedFromConnectedAccountActionPayload
 }
 
 export interface SetTokenConversionRate {
@@ -44,6 +54,7 @@ export interface SetTokenConversionRate {
 export type TokenActionTypes =
   | SetTokenBalance
   | SetTokenLoading
+  | SetTokenIsLoadedFromConnectedAccount
   | SetTokenConversionRate
 
 export interface UseTokenState {
@@ -62,6 +73,10 @@ export interface UseTokenState {
       conversionRate: number | string
     ) => TokenActionTypes
     setTokenLoading: (token: Token, loading: boolean) => TokenActionTypes
+    setTokenIsLoadedFromConnectedAccount: (
+      token: Token,
+      isLoadedFromConnectedAccount: boolean
+    ) => TokenActionTypes
     fetchTokenPriceUSD: (token: Token) => void
   }
 }

--- a/src/web3/connectors/coinbaseWallet.ts
+++ b/src/web3/connectors/coinbaseWallet.ts
@@ -12,7 +12,7 @@ interface CoinbaseWalletProvider {
 
 const rpcUrl = getEnvVariable(EnvVariable.ETH_HOSTNAME_HTTP)
 
-class CoinbaseWalletConnector extends WalletLinkConnector {
+export class CoinbaseWalletConnector extends WalletLinkConnector {
   activate = async (): Promise<ConnectorUpdate<string | number>> => {
     // Handle the case when MetaMask and Coinbase Wallet are both installed.
     const provider =

--- a/src/web3/connectors/metamask.ts
+++ b/src/web3/connectors/metamask.ts
@@ -30,8 +30,8 @@ export class InjectedProviderIsNotMetaMaskError extends Error {
   }
 }
 
-class MetaMask extends InjectedConnector {
-  private isMetaMask(provider: unknown): boolean {
+export class MetaMask extends InjectedConnector {
+  isMetaMask(provider: unknown): boolean {
     return (
       typeof provider === "object" &&
       provider !== null &&

--- a/src/web3/hooks/useERC20.ts
+++ b/src/web3/hooks/useERC20.ts
@@ -16,7 +16,11 @@ export const useErc20TokenContract: UseErc20Interface = (
   abi = ERC20_ABI
 ) => {
   const { account } = useWeb3React()
-  const { setTokenLoading, setTokenBalance } = useTokenState()
+  const {
+    setTokenLoading,
+    setTokenIsLoadedFromConnectedAccount,
+    setTokenBalance,
+  } = useTokenState()
   const { setTransactionStatus } = useTransaction()
 
   // TODO: Figure out how to type the ERC20 contract
@@ -59,6 +63,7 @@ export const useErc20TokenContract: UseErc20Interface = (
           const balance = await contract?.balanceOf(account as string)
           setTokenBalance(token, balance.toString())
           setTokenLoading(token, false)
+          setTokenIsLoadedFromConnectedAccount(token, true)
         } catch (error) {
           setTokenLoading(Token.Nu, false)
           console.log(

--- a/src/web3/utils/connectors.ts
+++ b/src/web3/utils/connectors.ts
@@ -9,7 +9,7 @@ import {
 
 export const getWalletTypeFromConnector = (
   connector: AbstractConnector | undefined
-): WalletType | undefined => {
+): WalletType | null => {
   if (connector instanceof MetaMask) {
     const isMetamask = connector.isMetaMask(window.ethereum)
     return isMetamask ? WalletType.Metamask : WalletType.TAHO
@@ -22,5 +22,5 @@ export const getWalletTypeFromConnector = (
 
   if (connector instanceof CoinbaseWalletConnector) return WalletType.Coinbase
 
-  return undefined
+  return null
 }

--- a/src/web3/utils/connectors.ts
+++ b/src/web3/utils/connectors.ts
@@ -1,0 +1,26 @@
+import { WalletType } from "../../enums"
+import {
+  AbstractConnector,
+  CoinbaseWalletConnector,
+  LedgerLiveConnector,
+  MetaMask,
+  WalletConnectConnector,
+} from "../connectors"
+
+export const getWalletTypeFromConnector = (
+  connector: AbstractConnector | undefined
+): WalletType | undefined => {
+  if (connector instanceof MetaMask) {
+    const isMetamask = connector.isMetaMask(window.ethereum)
+    return isMetamask ? WalletType.Metamask : WalletType.TAHO
+  }
+
+  if (connector instanceof LedgerLiveConnector) return WalletType.LedgerLive
+
+  if (connector instanceof WalletConnectConnector)
+    return WalletType.WalletConnect
+
+  if (connector instanceof CoinbaseWalletConnector) return WalletType.Coinbase
+
+  return undefined
+}


### PR DESCRIPTION
Ref: #731 #732 

(DESCRIPTION IN PROGRESS...)

Implements functionality that will send minting and unminting related events to Posthog.

## Breakdown of the events sent to Posthog:
### 1. Wallet Connected

Initially this event was meant to be sent when the `Connect Wallet` button is clicked but we didn't have information about the address that is connected yet at this point. We didn't have the balance info too.

That's why this event is sent when the `account` from the `useWeb3React` hook changes. Besides that, we also check if the token balance was loaded based on the currently connected account (with the new value in token store - `isLoadedFromConnectedAccount`). This was needed, because initially the `balance` value is set to 0 so we can't recognize if the value is loaded for account or not based on just `balance` and `loading` value.

With the `Wallet Connected` event we send three properties, which are:
- `walletType` - wallet type that user connected his wallet with, e.g. METAMASK, TAHO etc. It uses newly created function - `getWalletTypeFromConnector` - that will get the actual wallet type from the connector,
- `address` - eth address that was connected,
- `tbtcBalance` - current tbtc balance of the given account.

## 2. Wallet Disconnected

Simply just sends an event when the wallet is disconnected.

> (Minting flow:)

## 3. (Autocapture event) Deposit Address Generated

This is a default [autocapture event](https://posthog.com/docs/product-analytics/autocapture) but with additional parameters so that it's easier to track it. The addtional parameters are:
- `button-name` - it was used to identify those events before this PR. I'm leaving it just for compatibility with the previously catched events,
- `button-id` - id of the button. Should be unique and not contain any spaces,
- `button-text` - text that is displayed inside the button.

The autocapture tracks every click of the user by default, but additional parameters are added only when **Generate Deposit Address** button is clicked

## 4. (Autocapture event) Minting initiated 

This is a default [autocapture event](https://posthog.com/docs/product-analytics/autocapture) but with additional parameters so that it's easier to track it. The addtional parameters are:
- `button-name` - it was used to identify those events before this PR. I'm leaving it just for compatibility with the previously catched events,
- `button-id` - id of the button. Should be unique and not contain any spaces,
- `button-text` - text that is displayed inside the button,
- `deposited-btc-amount` - btc amount (1e8 precision) that was sent to the currently generated deposit address.

> (Unminting flow:)

## 5. (Autocapture event) Unminting initiated

This is a default [autocapture event](https://posthog.com/docs/product-analytics/autocapture) but with additional parameters so that it's easier to track it. The addtional parameters are:
- `button-name` - this button was not tracked before, but we still add `button-name` just for consistency,
- `button-id` - id of the button. Should be unique and not contain any spaces,
- `button-text` - text that is displayed inside the button,
- `unminted-tbtc-amount` - tbtc amount (1e18 precision) that user plan to unmint

**Note:** Bear in mind that this event is only for **Unmint** button in `InitiateMinting` modal. It does not track the `Unmint` button in `Unmint` page.