### PR TITLE
[Backport] Add TRM secrets to mainnet preview

### DIFF
--- a/.github/workflows/dashboard-mainnet.yml
+++ b/.github/workflows/dashboard-mainnet.yml
@@ -57,6 +57,8 @@ jobs:
           ELECTRUM_PORT: ${{ secrets.MAINNET_ELECTRUMX_PORT }}
           SENTRY_SUPPORT: true
           SENTRY_DSN: ${{ secrets.MAINNET_SENTRY_DSN }}
+          TRM_API_KEY: ${{ secrets.TEST_TRM_API_KEY }}
+          TRM_SUPPORT: ${{ secrets.TRM_SUPPORT }}
           WALLET_CONNECT_PROJECT_ID: ${{ secrets.WALLET_CONNECT_PROJECT_ID }}
           GOOGLE_TAG_MANAGER_SUPPORT: false
           GOOGLE_TAG_MANAGER_ID: ${{ secrets.GOOGLE_TAG_MANAGER_ID }}


### PR DESCRIPTION
Backport of: #762 

Adds TRM secrets to `build` job so that it's available on a mainnet preview. Here we are introducing a new secret variable - `TEST_TRM_API_KEY` - which will contain the TRM api key for testing environment (bust still for mainnet network).