### PR TITLE
Remove l2 test networks

### DIFF
--- a/src/components/Navbar/NetworkButton.tsx
+++ b/src/components/Navbar/NetworkButton.tsx
@@ -38,14 +38,14 @@ const getNetworkIcon = (chainId: number, colorMode: string): NetworkIconMap => {
             icon: <Icon as={ethereumLogo} boxSize="5" />,
             bg: grayBackground,
           },
-          [SupportedChainIds.ArbitrumSepolia]: {
-            icon: <Icon as={Arbitrum} boxSize="5" />,
-            bg: grayBackground,
-          },
-          [SupportedChainIds.BaseSepolia]: {
-            icon: <Icon as={Base} boxSize="5" />,
-            bg: "blue.500",
-          },
+          // [SupportedChainIds.ArbitrumSepolia]: {
+          //   icon: <Icon as={Arbitrum} boxSize="5" />,
+          //   bg: grayBackground,
+          // },
+          // [SupportedChainIds.BaseSepolia]: {
+          //   icon: <Icon as={Base} boxSize="5" />,
+          //   bg: "blue.500",
+          // },
         }
       : {
           [SupportedChainIds.Ethereum]: {

--- a/src/networks/enums/networks.ts
+++ b/src/networks/enums/networks.ts
@@ -9,18 +9,18 @@ export enum SupportedChainIds {
   Sepolia = 11155111,
   Localhost = 1337,
   Arbitrum = 42161,
-  ArbitrumSepolia = 421614,
   Base = 8453,
-  BaseSepolia = 84532,
+  // ArbitrumSepolia = 421614,
+  // BaseSepolia = 84532,
 }
 
 export enum TestnetChainIds {
   Sepolia = 11155111,
-  ArbitrumSepolia = 421614,
-  BaseSepolia = 84532,
   Localhost = 1337,
   Goerli = 5,
   Ropsten = 3,
+  // ArbitrumSepolia = 421614,
+  // BaseSepolia = 84532,
 }
 
 export enum AlchemyName {

--- a/src/networks/utils/networks.ts
+++ b/src/networks/utils/networks.ts
@@ -101,42 +101,42 @@ export const networks: Network[] = [
       blockExplorerUrls: [createExplorerPrefix(SupportedChainIds.Sepolia)],
     },
   },
-  {
-    chainId: SupportedChainIds.ArbitrumSepolia,
-    name: "Arbitrum",
-    layer: Layer.L2,
-    networkType: NetworkType.Testnet,
-    alchemyName: AlchemyName.Arbitrum,
-    chainParameters: {
-      chainId: toHex(SupportedChainIds.ArbitrumSepolia),
-      chainName: "Arbitrum Sepolia",
-      nativeCurrency: {
-        name: NativeCurrency.SepoliaEther,
-        symbol: ETH_SYMBOL,
-        decimals: DECIMALS,
-      },
-      rpcUrls: [PublicRpcUrls.ArbitrumSepolia],
-      blockExplorerUrls: [
-        createExplorerPrefix(SupportedChainIds.ArbitrumSepolia),
-      ],
-    },
-  },
-  {
-    chainId: SupportedChainIds.BaseSepolia,
-    name: "Base",
-    layer: Layer.L2,
-    networkType: NetworkType.Testnet,
-    alchemyName: AlchemyName.Base,
-    chainParameters: {
-      chainId: toHex(SupportedChainIds.BaseSepolia),
-      chainName: "Base Sepolia",
-      nativeCurrency: {
-        name: NativeCurrency.SepoliaEther,
-        symbol: ETH_SYMBOL,
-        decimals: DECIMALS,
-      },
-      rpcUrls: [PublicRpcUrls.BaseSepolia],
-      blockExplorerUrls: [createExplorerPrefix(SupportedChainIds.BaseSepolia)],
-    },
-  },
+  // {
+  //   chainId: SupportedChainIds.ArbitrumSepolia,
+  //   name: "Arbitrum",
+  //   layer: Layer.L2,
+  //   networkType: NetworkType.Testnet,
+  //   alchemyName: AlchemyName.Arbitrum,
+  //   chainParameters: {
+  //     chainId: toHex(SupportedChainIds.ArbitrumSepolia),
+  //     chainName: "Arbitrum Sepolia",
+  //     nativeCurrency: {
+  //       name: NativeCurrency.SepoliaEther,
+  //       symbol: ETH_SYMBOL,
+  //       decimals: DECIMALS,
+  //     },
+  //     rpcUrls: [PublicRpcUrls.ArbitrumSepolia],
+  //     blockExplorerUrls: [
+  //       createExplorerPrefix(SupportedChainIds.ArbitrumSepolia),
+  //     ],
+  //   },
+  // },
+  // {
+  //   chainId: SupportedChainIds.BaseSepolia,
+  //   name: "Base",
+  //   layer: Layer.L2,
+  //   networkType: NetworkType.Testnet,
+  //   alchemyName: AlchemyName.Base,
+  //   chainParameters: {
+  //     chainId: toHex(SupportedChainIds.BaseSepolia),
+  //     chainName: "Base Sepolia",
+  //     nativeCurrency: {
+  //       name: NativeCurrency.SepoliaEther,
+  //       symbol: ETH_SYMBOL,
+  //       decimals: DECIMALS,
+  //     },
+  //     rpcUrls: [PublicRpcUrls.BaseSepolia],
+  //     blockExplorerUrls: [createExplorerPrefix(SupportedChainIds.BaseSepolia)],
+  //   },
+  // },
 ]


### PR DESCRIPTION
## Description

This PR removes the support of L2 test networks of the app.

- [x] [remove l2 test networks](https://github.com/threshold-network/token-dashboard/commit/053b2c08ad311d25723f157d2d1d63fd91d03421)

## Type of change

- [x]  💅 Refactor (Non-breaking Change)

## Notice

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/threshold-network/token-dashboard/pulls) for the same update/change?