### PR TITLE
[backport] refactor: remove arbitrum tx max fee

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@keep-network/keep-ecdsa": "development",
     "@keep-network/random-beacon": "development",
     "@keep-network/tbtc": "development",
-    "@keep-network/tbtc-v2.ts": "2.4.5",
+    "@keep-network/tbtc-v2.ts": "2.5.0",
     "@ledgerhq/connect-kit-loader": "1.1.8",
     "@ledgerhq/wallet-api-client": "^1.2.0",
     "@ledgerhq/wallet-api-client-react": "^1.1.1",

--- a/src/pages/tBTC/Bridge/DepositDetails.tsx
+++ b/src/pages/tBTC/Bridge/DepositDetails.tsx
@@ -607,15 +607,6 @@ const StepSwitcher: FC = () => {
               precision={6}
               higherPrecision={8}
             />
-            {chainId === SupportedChainIds.Arbitrum && (
-              <TransactionDetailsAmountItem
-                label="Cross Chain Fee"
-                amount={crossChainFee}
-                suffixItem="tBTC"
-                precision={6}
-                higherPrecision={8}
-              />
-            )}
           </List>
           <ButtonLink size="lg" mt="8" mb="8" to="/tBTC" isFullWidth>
             New mint

--- a/src/pages/tBTC/Bridge/components/MintingTransactionDetails.tsx
+++ b/src/pages/tBTC/Bridge/components/MintingTransactionDetails.tsx
@@ -16,8 +16,6 @@ const MintingTransactionDetails = () => {
     ethAddress,
     crossChainFee,
   } = useTbtcState()
-  const { chainId } = useIsActive()
-
   return (
     <List spacing="2" mb="6">
       <TransactionDetailsAmountItem
@@ -39,15 +37,6 @@ const MintingTransactionDetails = () => {
         precision={6}
         higherPrecision={8}
       />
-      {chainId === SupportedChainIds.Arbitrum && (
-        <TransactionDetailsAmountItem
-          label="Cross Chain Fee"
-          amount={crossChainFee}
-          suffixItem="tBTC"
-          precision={6}
-          higherPrecision={8}
-        />
-      )}
       <TransactionDetailsItem
         label="ETH address"
         value={shortenAddress(ethAddress)}

--- a/src/pages/tBTC/Bridge/components/TbtcFees.tsx
+++ b/src/pages/tBTC/Bridge/components/TbtcFees.tsx
@@ -11,8 +11,6 @@ const TbtcFees = () => {
     isFetching,
   } = useFetchTBTCFees()
 
-  const { chainId } = useIsActive()
-
   return (
     <List spacing="2" mb="6">
       <TransactionDetailsAmountItem
@@ -27,16 +25,6 @@ const TbtcFees = () => {
         suffixItem="%"
         isFetching={isFetching}
       />
-      {chainId === SupportedChainIds.Arbitrum && (
-        <TransactionDetailsAmountItem
-          label="Cross Chain Fee"
-          amount={depositTxMaxFee}
-          suffixItem="tBTC"
-          precision={6}
-          higherPrecision={8}
-          isFetching={isFetching}
-        />
-      )}
     </List>
   )
 }

--- a/src/threshold-ts/tbtc/index.ts
+++ b/src/threshold-ts/tbtc/index.ts
@@ -936,9 +936,6 @@ export class TBTC implements ITBTC {
     optimisticMintFee: BigNumber
     amountToMint: BigNumber
   } {
-    const isArbitrumNetworkConnected =
-      this.ethereumChainId === SupportedChainIds.Arbitrum
-
     const amountToMintAfterTreasuryFee = depositAmount
       .sub(treasuryFee)
       .mul(this._satoshiMultiplier)
@@ -948,13 +945,8 @@ export class TBTC implements ITBTC {
       ? amountToMintAfterTreasuryFee.div(optimisticMintingFeeDivisor)
       : ZERO
 
-    const networkSpecificFee = isArbitrumNetworkConnected
-      ? depositTxMaxFee.mul(this._satoshiMultiplier)
-      : ZERO
-
-    const finalAmountToMint = amountToMintAfterTreasuryFee
-      .sub(optimisticMintFee)
-      .sub(networkSpecificFee)
+    const finalAmountToMint =
+      amountToMintAfterTreasuryFee.sub(optimisticMintFee)
 
     return {
       optimisticMintFee: optimisticMintFee,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,6 +3299,17 @@
   resolved "https://registry.yarnpkg.com/@keep-network/bitcoin-spv-sol/-/bitcoin-spv-sol-3.4.0-solc-0.8.tgz#8b44c246ffab8ea993efe196f6bf385b1a3b84dc"
   integrity sha512-KlpY9BbasyLvYXSS7dsJktgRChu/yjdFLOX8ldGA/pltLicCm/l0F4oqxL8wSws9XD12vq9x0B5qzPygVLB2TQ==
 
+"@keep-network/ecdsa@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.0.1.tgz#f9de5e4ae68c48493b8a46d1d956c8bc157b1145"
+  integrity sha512-51Ef0FGak9dzuTF4e80ed1G2+3v+kQYPieYa3hX7eKg3XG0/C/xOtMSpIOxU7IMdYBHeeH+hRIqDiL5AuOidOg==
+  dependencies:
+    "@keep-network/random-beacon" "2.0.0"
+    "@keep-network/sortition-pools" "2.0.0"
+    "@openzeppelin/contracts" "^4.6.0"
+    "@openzeppelin/contracts-upgradeable" "^4.6.0"
+    "@threshold-network/solidity-contracts" "1.2.1"
+
 "@keep-network/ecdsa@2.1.0-dev.19":
   version "2.1.0-dev.19"
   resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.1.0-dev.19.tgz#749af8bd65f70135d1734f7c5f9bff82ae308fdb"
@@ -3397,13 +3408,13 @@
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@keep-network/tbtc-v2.ts@2.4.5":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-2.4.5.tgz#cc524e96c93782113ae299344f69db2aa2b127ea"
-  integrity sha512-C0fXWSfYVdWR86HiqzWK0e41qlCh7DqsT+bjqvBJigLliTGumDVmC7bIF7tUkclW7Xc5SjZb067SLAB87B7rcw==
+"@keep-network/tbtc-v2.ts@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2.ts/-/tbtc-v2.ts-2.5.0.tgz#20ec4c965209f4a5212f6726ec150358160578c1"
+  integrity sha512-22+sRFgjlzRqFa7kF8Z+kqG3QKvF8KldS6kvhIQ07UcT+t+74gjyHwcKZB077DvR8Co8m5bD4ow3gOITJvbZuw==
   dependencies:
     "@bitcoinerlab/secp256k1" "^1.0.5"
-    "@keep-network/ecdsa" "2.1.0-dev.19"
+    "@keep-network/ecdsa" "2.0.1"
     "@keep-network/tbtc-v2" "1.7.2"
     bignumber.js "^9.1.2"
     bitcoinjs-lib "^6.1.5"


### PR DESCRIPTION
Backport of https://github.com/threshold-network/token-dashboard/pull/817

This backport PR removes the cross-chain deposit tx max fee display for the user, following the ArbitrumL1BitcoinDepositor contract upgrade.