### PR TITLE
chore: add babel plugins and webpack rule

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -11,6 +11,8 @@ module.exports = {
        * ECPair library error used by "@keep-network/tbtc-v2.ts"
        */
       ["@babel/plugin-transform-class-properties", { loose: true }],
+      ["@babel/plugin-proposal-private-methods", { loose: true }],
+      ["@babel/plugin-proposal-private-property-in-object", { loose: true }],
     ],
   },
   jest: {
@@ -36,6 +38,11 @@ module.exports = {
   },
   webpack: {
     configure: (webpackConfig) => {
+      webpackConfig.module.rules.push({
+        test: /\.mjs$/,
+        include: /node_modules/,
+        type: "javascript/auto",
+      })
       // Add webpack plugins
       webpackConfig.plugins = [
         ...webpackConfig.plugins,


### PR DESCRIPTION
### Summary

This PR fixes a build failure in the token dashboard frontend caused by an issue with `rpc-websockets`, a transitive dependency. The compilation was failing with the error `Can't import the named export 'Buffer' from non EcmaScript module` when processing an `.mjs` file.

### Problem

The build process was not correctly configured to handle `.mjs` files from dependencies, leading to issues with named imports for Node.js polyfills like `Buffer`. Additionally, several Babel warnings were present due to inconsistent configuration for class property plugins.

### Solution

The following changes were made to `new-token-dashboard/craco.config.js` to resolve the issue:

1.  **Added Babel Plugins**:
    -   `@babel/plugin-proposal-private-methods`
    -   `@babel/plugin-proposal-private-property-in-object`
    
    These were added with `{ loose: true }` to silence warnings and ensure consistent transpilation behavior for class properties, aligning with the existing configuration.

2.  **Added Webpack Rule for `.mjs` files**:
    -   A new rule was added to the Webpack config to process `.mjs` files within `node_modules` as `javascript/auto`. This ensures that ES modules with the `.mjs` extension are handled correctly, resolving the named import issue.

These changes ensure the project compiles successfully and make the build configuration more robust for handling modern JavaScript module formats. 