### PR TITLE
feat: add deposit data telemetry to be retained in the backend

### DIFF
--- a/src/enums/api.ts
+++ b/src/enums/api.ts
@@ -7,6 +7,7 @@ export enum ApiUrl {
 
 export enum endpointUrl {
   TRM_WALLET_SCREENING = "/trm/screen",
+  TBTC_DEPOSIT_DATA = "/deposit-data",
   CURVE_ETHEREUM_POOL = "/getPools/ethereum/factory",
   COINGECKO_SIMPLE_PRICE = "/simple/price",
   COINGECKO_VS_CURRENCY = "vs_currencies",

--- a/src/hooks/tbtc/useDepositTelemetry.ts
+++ b/src/hooks/tbtc/useDepositTelemetry.ts
@@ -58,10 +58,12 @@ export const useDepositTelemetry = (network: BitcoinNetwork) => {
       try {
         await axios.post(
           `${ApiUrl.TBTC_EXPLORER}${endpointUrl.TBTC_DEPOSIT_DATA}`,
-          requestBody
+          requestBody,
+          { timeout: 10000 }
         )
       } catch (error) {
-        throw new Error("Failed to submit deposit telemetry")
+        console.error("Failed to submit deposit telemetry:", error)
+        throw new Error("Failed to submit deposit telemetry", { cause: error })
       }
     },
     [verifyDepositAddress, network, captureMessage]

--- a/src/hooks/tbtc/useDepositTelemetry.ts
+++ b/src/hooks/tbtc/useDepositTelemetry.ts
@@ -62,7 +62,6 @@ export const useDepositTelemetry = (network: BitcoinNetwork) => {
           { timeout: 10000 }
         )
       } catch (error) {
-        console.error("Failed to submit deposit telemetry:", error)
         throw new Error("Failed to submit deposit telemetry", { cause: error })
       }
     },

--- a/src/hooks/tbtc/useDepositTelemetry.ts
+++ b/src/hooks/tbtc/useDepositTelemetry.ts
@@ -1,8 +1,10 @@
+import axios from "axios"
 import { DepositReceipt } from "@keep-network/tbtc-v2.ts"
 import { useCallback } from "react"
 import { BitcoinNetwork } from "../../threshold-ts/types"
 import { verifyDepositAddress } from "../../utils/verifyDepositAddress"
 import { useCaptureMessage } from "../sentry"
+import { ApiUrl, endpointUrl } from "../../enums"
 
 export const useDepositTelemetry = (network: BitcoinNetwork) => {
   const captureMessage = useCaptureMessage()
@@ -40,6 +42,27 @@ export const useDepositTelemetry = (network: BitcoinNetwork) => {
           "verification.status": status,
         }
       )
+
+      const requestBody = {
+        depositAddress,
+        depositor: depositor.identifierHex,
+        blindingFactor: blindingFactor.toString(),
+        walletPublicKeyHash: walletPublicKeyHash.toString(),
+        refundPublicKeyHash: refundPublicKeyHash.toString(),
+        refundLocktime: refundLocktime.toString(),
+        extraData: extraData?.toString(),
+        verificationStatus: status,
+        verificationResponse: response,
+      }
+
+      try {
+        await axios.post(
+          `${ApiUrl.TBTC_EXPLORER}${endpointUrl.TBTC_DEPOSIT_DATA}`,
+          requestBody
+        )
+      } catch (error) {
+        throw new Error("Failed to submit deposit telemetry")
+      }
     },
     [verifyDepositAddress, network, captureMessage]
   )

--- a/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
@@ -171,7 +171,8 @@ export const ProvideDataComponent: FC<{
   const { account, chainId } = useIsActive()
   const { isNonEVMActive, nonEVMPublicKey, nonEVMChainName } =
     useNonEVMConnection()
-  const { setDepositDataInLocalStorage } = useTBTCDepositDataFromLocalStorage()
+  const { setDepositDataInLocalStorage, removeDepositDataFromLocalStorage } =
+    useTBTCDepositDataFromLocalStorage()
   const depositTelemetry = useDepositTelemetry(threshold.tbtc.bitcoinNetwork)
   const connectedAccount = account || nonEVMPublicKey
   const { openModal, closeModal: closeModalFromHook, modalType } = useModal()
@@ -263,7 +264,13 @@ export const ProvideDataComponent: FC<{
         networkName
       )
 
-      depositTelemetry(receipt, btcDepositAddress)
+      try {
+        await depositTelemetry(receipt, btcDepositAddress)
+      } catch (error) {
+        removeDepositDataFromLocalStorage(networkName)
+        setSubmitButtonLoading(false)
+        return
+      }
 
       // if the user has NOT declined the json file, ask the user if they want to accept the new file
       if (shouldDownloadDepositReceipt) {

--- a/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
+++ b/src/pages/tBTC/Bridge/Minting/ProvideData.tsx
@@ -41,6 +41,7 @@ import TbtcFees from "../components/TbtcFees"
 import { useIsActive } from "../../../../hooks/useIsActive"
 import { PosthogButtonId } from "../../../../types/posthog"
 import SubmitTxButton from "../../../../components/SubmitTxButton"
+import { Toast } from "../../../../components/Toast"
 import { Deposit } from "@keep-network/tbtc-v2.ts"
 import { useModal } from "../../../../hooks/useModal"
 import { ModalType } from "../../../../enums"
@@ -162,8 +163,9 @@ const MintingProcessForm = withFormik<MintingProcessFormProps, FormValues>({
 export const ProvideDataComponent: FC<{
   onPreviousStepClick: (previosuStep: MintingStep) => void
 }> = ({ onPreviousStepClick }) => {
-  const { updateState } = useTbtcState()
+  const { updateState, resetDepositData } = useTbtcState()
   const [isSubmitButtonLoading, setSubmitButtonLoading] = useState(false)
+  const [telemetryFailed, setTelemetryFailed] = useState(false)
   const [stagedDepositValues, setStagedDepositValues] =
     useState<FormValues | null>(null)
   const formRef = useRef<FormikProps<FormValues>>(null)
@@ -218,6 +220,7 @@ export const ProvideDataComponent: FC<{
       const chainName =
         nonEVMChainName || getEthereumNetworkNameFromChainId(chainId)
 
+      setTelemetryFailed(false)
       setSubmitButtonLoading(true)
 
       let deposit: Deposit
@@ -267,8 +270,11 @@ export const ProvideDataComponent: FC<{
       try {
         await depositTelemetry(receipt, btcDepositAddress)
       } catch (error) {
+        threshold.tbtc.removeDepositData()
+        resetDepositData()
         removeDepositDataFromLocalStorage(networkName)
         setSubmitButtonLoading(false)
+        setTelemetryFailed(true)
         return
       }
 
@@ -303,6 +309,15 @@ export const ProvideDataComponent: FC<{
 
   return (
     <>
+      {telemetryFailed && (
+        <Toast
+          title="We couldn't submit deposit telemetry. Please try again."
+          status="error"
+          duration={8000}
+          top={3}
+          zIndex={1}
+        />
+      )}
       <BridgeProcessCardTitle onPreviousStepClick={onPreviousStepClick} />
       <BridgeProcessCardSubTitle
         stepText="Step 1"


### PR DESCRIPTION
## PR description

### Summary
This change sends deposit telemetry to the TBTC Explorer API for data retention. Telemetry is posted when a new deposit address is generated so the backend has a durable record of the event.

- Endpoint: `POST ApiUrl.TBTC_EXPLORER + endpointUrl.TBTC_DEPOSIT_DATA` → `https://api.tbtcscan.com/deposit-data`
- Payload mirrors the Sentry context: `depositAddress`, `depositor.identifierHex`, `blindingFactor`, `walletPublicKeyHash`, `refundPublicKeyHash`, `refundLocktime`, `extraData`, `verificationStatus`, `verificationResponse`.

### Flow behavior
If telemetry transmission fails (network/4xx/5xx), the minting flow is cancelled: staged deposit data is removed from local storage and we do not advance the `mintingStep`.

### Changes
- `src/hooks/tbtc/useDepositTelemetry.ts`
  - Send telemetry via axios to `ApiUrl.TBTC_EXPLORER + endpointUrl.TBTC_DEPOSIT_DATA`.
  - Wrap in `try/catch` and explicitly throw on failure to surface the error to the caller.
- `src/pages/tBTC/Bridge/Minting/ProvideData.tsx`
  - Await telemetry; on failure, clear deposit data from local storage and return early (no step advancement).
- `src/enums/api.ts`
  - Add `endpointUrl.TBTC_DEPOSIT_DATA = "/deposit-data"`.

### Telemetry payload example
```json
{
  "depositAddress": "<btc_deposit_address>",
  "depositor": "<identifierHex>",
  "blindingFactor": "<string>",
  "walletPublicKeyHash": "<string>",
  "refundPublicKeyHash": "<string>",
  "refundLocktime": "<string>",
  "extraData": "<string-or-empty>",
  "verificationStatus": "<status>",
  "verificationResponse": "<raw-response-or-null>"
}
```

### Rationale
- Ensures deposit events are retained by the backend for auditing, compliance, and analytics.
- Avoids proceeding when telemetry cannot be recorded, keeping UI and backend in sync.

### Testing
- Success path: telemetry returns 200 → proceeds to `MintingStep.Deposit`.
- Failure path: simulate 4xx/5xx/timeout → staged local storage cleared; loading stops; remains on current step.
- Validate payload fields and endpoint URL.

### Risk / Impact
- If TBTC Explorer is unavailable, deposit generation is intentionally blocked until telemetry can be recorded.

### Checklist
- [x] Telemetry posted to TBTC Explorer for data retention
- [x] Explicit error thrown on telemetry failure
- [x] Flow cancellation and storage cleanup on error
- [x] Payload parity with Sentry fields